### PR TITLE
Update README.md with more detailed install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,17 @@ Requires Neovim 0.10
 
 ## Setup
 
-You need to install the language server yourself. I did this by installing C#
-dev kit on vscode. I then checked `htop` and found the .dll file that was ran.
-Move the entire directory with all the binaries to
-`~/.local/share/nvim/roslyn`. The path to the dll that this plugin runs is:
-`~/.local/share/nvim/roslyn/Microsoft.CodeAnalysis.LanguageServer.dll`
+### Installing Roslyn
+1. Navigate to https://dev.azure.com/azure-public/vside/_artifacts/feed/vs-impl to see the latest package feed for `Microsoft.CodeAnalysis.LanguageServer`
+2. Locate the version matching your OS + Arch and click to open it, for example `Microsoft.CodeAnalysis.LanguageServer.linux-x64` (Note that some OS/Arch specific packages may have an extra version ahead of the "core" non specific package)
+3. On the package page, click the "Download" button to begin downloading it's .nupkg
+   a. (Note, if you need to get a copyable link for the download you can obtain it on chrome by then opening the downloads page, right clicking the file just downloaded, and hitting "copy link address"
+4. `.nupkg` files can be opened the same as a zip, in the case of linux you can just use `unzip` on the downloaded the file as if it was a `.zip`.
+5. Copy the contents of `<zip root>/content/LanguageServer/<yourArch/` to `~/.local/share/nvim/roslyn`
+   a. if you did it right the file `~/.local/share/nvim/roslyn/Microsoft.CodeAnalysis.LanguageServer.dll` should exist (along with many other .dlls and etc in that dir)
+6. To test it is working, `cd` into the aformentioned roslyn directory and invoke `dotnet Microsoft.CodeAnalysis.LanguageServer.dll --version`, it should output its version
+
+### Installing the nvim plugin
 
 Install `seblj/roslyn.nvim` using your plugin manager.
 
@@ -26,7 +32,7 @@ require("roslyn").setup({
 
 1. The plugin will look for a `.sln` file in parent
    directories until it finds one. Make sure to have a `.sln` file somewhere in
-   a parent dir.
+   a parent dir. 
 2. If it only finds one `.sln` file, it will use that to start the server.
    If it finds multiple, you have to run `CSTarget` to choose which target you want to use.
 3. You'll see two notifications if everything goes well. The first one will say
@@ -35,6 +41,10 @@ require("roslyn").setup({
    `Roslyn project initialization complete`, it means that the server indexed
    your `sln`, only after you see the second notification will the `go to definition`
    and other lsp features be available.
+
+## Importan note!
+
+Roslyn requires that `.csproj` projects are referenced by the matched `.sln` it discovers, otherwise it won't actually discover and load suggestions for `.cs` files under the `.csproj`. Ensure you `dotnet sln add` your projects to the `.sln` or Roslyn won't load up properly!
 
 ## Features
 


### PR DESCRIPTION
The existing instructions that indicate one should install the C# Dev Kit is potentially a violation of ToS / Licensing, the C# Dev Kit is licensed to only be used with Visual Studio Code.

However the specific nuget package we need (Microsoft.CodeAnalysis.LanguageServer) is explicitly broken out to be licensed for open use, so we want to instruct people to download it directly to avoid encouraging people to potentially violate license agreements (and potential irk microsoft's legal team)

Downloading it directly off their nuget feed and then unpacking it is the best way to stick to their license on the package (and it means not needing to have to install VS Code and a plugin for it at all)