### PR TITLE
Allow using already wrapped executable

### DIFF
--- a/lua/roslyn/hacks.lua
+++ b/lua/roslyn/hacks.lua
@@ -1,8 +1,8 @@
 local M = {}
 
 ---@param handler function
----@param roslyn_config InternalRoslynNvimConfig
-function M.with_filtered_watchers(handler, roslyn_config)
+---@param filewatching boolean
+function M.with_filtered_watchers(handler, filewatching)
     return function(err, res, ctx, config)
         for _, reg in ipairs(res.registrations) do
             if reg.method == vim.lsp.protocol.Methods.workspace_didChangeWatchedFiles then
@@ -34,7 +34,7 @@ function M.with_filtered_watchers(handler, roslyn_config)
                     return true
                 end, reg.registerOptions.watchers)
 
-                reg.registerOptions.watchers = roslyn_config.filewatching and watchers or {}
+                reg.registerOptions.watchers = filewatching and watchers or {}
             end
         end
         return handler(err, res, ctx, config)

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -148,6 +148,7 @@ local function get_default_capabilities(roslyn_config)
 end
 
 ---@param exe string|string[]
+---@return string[]
 local function get_cmd(exe)
     local default_lsp_args =
         { "--logLevel=Information", "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path()) }
@@ -175,7 +176,7 @@ local M = {}
 
 ---@class InternalRoslynNvimConfig
 ---@field filewatching boolean
----@field exe string
+---@field exe? string
 ---@field config vim.lsp.ClientConfig
 
 ---@class RoslynNvimConfig
@@ -190,11 +191,7 @@ function M.setup(config)
     ---@type InternalRoslynNvimConfig
     local default_config = {
         filewatching = true,
-        exe = vim.fs.joinpath(
-            vim.fn.stdpath("data") --[[@as string]],
-            "roslyn",
-            "Microsoft.CodeAnalysis.LanguageServer.dll"
-        ),
+        exe = nil,
         -- I don't know how to make this a partial type.
         ---@diagnostic disable-next-line: missing-fields
         config = {

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -159,6 +159,15 @@ local function get_cmd(exe)
         return vim.list_extend(vim.deepcopy(exe), default_lsp_args)
     elseif vim.uv.fs_stat(mason_installation) then
         return vim.list_extend({ mason_installation }, default_lsp_args)
+    else
+        return vim.list_extend({
+            "dotnet",
+            vim.fs.joinpath(
+                vim.fn.stdpath("data") --[[@as string]],
+                "roslyn",
+                "Microsoft.CodeAnalysis.LanguageServer.dll"
+            ),
+        }, default_lsp_args)
     end
 end
 

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -86,47 +86,43 @@ local function run_roslyn(exe, target, config)
         }
     end
 
-    vim.system(
-        cmd,
-        {
-            detach = not vim.uv.os_uname().version:find("Windows"),
-            stdout = function(_, data)
-                if not data then
-                    return
-                end
+    vim.system(cmd, {
+        detach = not vim.uv.os_uname().version:find("Windows"),
+        stdout = function(_, data)
+            if not data then
+                return
+            end
 
-                -- try parse data as json
-                local success, json_obj = pcall(vim.json.decode, data)
-                if not success then
-                    return
-                end
+            -- try parse data as json
+            local success, json_obj = pcall(vim.json.decode, data)
+            if not success then
+                return
+            end
 
-                local pipe_name = json_obj["pipeName"]
-                if not pipe_name then
-                    return
-                end
+            local pipe_name = json_obj["pipeName"]
+            if not pipe_name then
+                return
+            end
 
-                -- Cache the pipe name so we only start roslyn once.
-                _pipe_name = pipe_name
+            -- Cache the pipe name so we only start roslyn once.
+            _pipe_name = pipe_name
 
-                vim.schedule(function()
-                    lsp_start(pipe_name, target, config)
-                end)
-            end,
-            stderr_handler = function(_, chunk)
-                local log = require("vim.lsp.log")
-                if chunk and log.error() then
-                    log.error("rpc", "dotnet", "stderr", chunk)
-                end
-            end,
-        },
-        function()
-            _pipe_name = nil
             vim.schedule(function()
-                vim.notify("Roslyn server stopped", vim.log.levels.ERROR)
+                lsp_start(pipe_name, target, config)
             end)
-        end
-    )
+        end,
+        stderr_handler = function(_, chunk)
+            local log = require("vim.lsp.log")
+            if chunk and log.error() then
+                log.error("rpc", "dotnet", "stderr", chunk)
+            end
+        end,
+    }, function()
+        _pipe_name = nil
+        vim.schedule(function()
+            vim.notify("Roslyn server stopped", vim.log.levels.ERROR)
+        end)
+    end)
 end
 
 -- Assigns the default capabilities from cmp if installed, and the capabilities from neovim
@@ -135,11 +131,11 @@ end
 local function get_default_capabilities(roslyn_config)
     local ok, cmp_nvim_lsp = pcall(require, "cmp_nvim_lsp")
     local capabilities = ok
-        and vim.tbl_deep_extend(
-            "force",
-            vim.lsp.protocol.make_client_capabilities(),
-            cmp_nvim_lsp.default_capabilities()
-        )
+            and vim.tbl_deep_extend(
+                "force",
+                vim.lsp.protocol.make_client_capabilities(),
+                cmp_nvim_lsp.default_capabilities()
+            )
         or vim.lsp.protocol.make_client_capabilities()
 
     -- This actually tells the server that the client can do filewatching.
@@ -214,7 +210,7 @@ function M.setup(config)
 
             local exe = roslyn_config.exe
             local mason_installation = get_mason_installation()
-            if not vim.uv.fs_stat(exe) and not vim.uv.fs_stat(mason_installation) then
+            if not vim.uv.fs_stat(exe) and not vim.uv.fs_stat(mason_installation) and not vim.fn.executable(exe) then
                 return vim.notify(
                     string.format("%s not found. Refer to README on how to setup the language server", exe),
                     vim.log.levels.INFO

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -211,11 +211,6 @@ function M.setup(config)
         )
     end
 
-    local filewatching = roslyn_config.filewatching
-    if filewatching == nil then
-        filewatching = true
-    end
-
     vim.api.nvim_create_autocmd("FileType", {
         group = vim.api.nvim_create_augroup("Roslyn", { clear = true }),
         pattern = { "cs" },
@@ -234,7 +229,7 @@ function M.setup(config)
 
             -- Roslyn is already running, so just call `vim.lsp.start` to handle everything
             if _pipe_name and known_solutions[sln_directory] then
-                lsp_start(_pipe_name, known_solutions[sln_directory], roslyn_config.config, filewatching)
+                lsp_start(_pipe_name, known_solutions[sln_directory], roslyn_config.config, roslyn_config.filewatching)
                 return
             end
 
@@ -248,15 +243,15 @@ function M.setup(config)
                 vim.ui.select(all_sln_files, { prompt = "Select target solution: " }, function(sln_file)
                     known_solutions[sln_directory] = sln_file
                     if _pipe_name then
-                        lsp_start(_pipe_name, sln_file, roslyn_config.config, filewatching)
+                        lsp_start(_pipe_name, sln_file, roslyn_config.config, roslyn_config.filewatching)
                     else
-                        run_roslyn(cmd, sln_file, roslyn_config.config, filewatching)
+                        run_roslyn(cmd, sln_file, roslyn_config.config, roslyn_config.filewatching)
                     end
                 end)
             end, { desc = "Selects the sln file for the current buffer" })
 
             if #all_sln_files == 1 then
-                run_roslyn(cmd, all_sln_files[1], roslyn_config.config, filewatching)
+                run_roslyn(cmd, all_sln_files[1], roslyn_config.config, roslyn_config.filewatching)
                 known_solutions[sln_directory] = all_sln_files[1]
 
                 return
@@ -266,7 +261,7 @@ function M.setup(config)
             local predicted_sln_file = require("roslyn.slnutils").predict_sln_file(opt.buf)
 
             if predicted_sln_file then
-                run_roslyn(cmd, predicted_sln_file, roslyn_config.config, filewatching)
+                run_roslyn(cmd, predicted_sln_file, roslyn_config.config, roslyn_config.filewatching)
                 known_solutions[sln_directory] = predicted_sln_file
             end
 


### PR DESCRIPTION
Extends the language server finding logic to support an executable available in `PATH`

This is to cater to my personal use case, where I have the lsp installed via a method other than mason (nix)

Closes #14 