### PR TITLE
Support only a single known solution at a time

### DIFF
--- a/lua/roslyn/server.lua
+++ b/lua/roslyn/server.lua
@@ -48,23 +48,15 @@ function M.start_server(cmd, with_pipe_name)
         end,
     }, function()
         _pipe_name = nil
-        vim.schedule(function()
-            vim.notify("Roslyn server stopped", vim.log.levels.ERROR)
-        end)
     end)
 end
 
 function M.stop_server()
-    if not _server_object then
-        return
+    if _server_object then
+        _server_object:kill(9)
     end
-
-    _server_object:kill(9)
     _pipe_name = nil
     _server_object = nil
-    vim.schedule(function()
-        vim.notify("Stopping roslyn process", vim.log.levels.INFO)
-    end)
 end
 
 return M

--- a/lua/roslyn/slnutils.lua
+++ b/lua/roslyn/slnutils.lua
@@ -1,8 +1,69 @@
----@param file_paths string[]
----@param search_string string
+local M = {}
+
+---@class RoslynNvimDirectoryWithFiles
+---@field directory string
+---@field files string[]
+
+---Gets the root directory of the first project file and find all related project file to that directory
+---@param buffer integer
+---@return RoslynNvimDirectoryWithFiles?
+function M.get_project_files(buffer)
+    local directory = vim.fs.root(buffer, function(name)
+        return name:match("%.csproj$") ~= nil
+    end)
+
+    if not directory then
+        return nil
+    end
+
+    local files = vim.fs.find(function(name, _)
+        return name:match("%.csproj$")
+    end, { path = directory, limit = math.huge })
+
+    return {
+        directory = directory,
+        files = files,
+    }
+end
+
+---Find the solution file from the current buffer.
+---Recursively see if we have any other solution files, to potentially
+---give th user an option to choose which solution file to use
+---@param buffer integer
+---@return string[]?
+function M.get_solution_files(buffer)
+    local directory = vim.fs.root(buffer, function(name)
+        return name:match("%.sln$") ~= nil
+    end)
+
+    if not directory then
+        return nil
+    end
+
+    return vim.fs.find(function(name, _)
+        return name:match("%.sln$")
+    end, { type = "file", limit = math.huge, path = directory })
+end
+
+--- Find a path to sln file that is likely to be the one that the current buffer
+--- belongs to. Ability to predict the right sln file automates the process of starting
+--- LSP, without requiring the user to invoke CSTarget each time the solution is open.
+--- The prediction assumes that the nearest csproj file (in one of parent dirs from buffer)
+--- should be a part of the sln file that the user intended to open.
+---@param buffer integer
+---@param sln_files string[]
 ---@return string?
-local function get_filepath_containing_string(file_paths, search_string)
-    for _, file_path in ipairs(file_paths) do
+function M.predict_sln_file(buffer, sln_files)
+    local csproj = M.get_project_files(buffer)
+    if not csproj or #csproj.files > 1 then
+        return nil
+    end
+
+    local csproj_filename = vim.fn.fnamemodify(csproj.files[1], ":t")
+
+    -- Look for a solution file that contains the name of the project
+    -- Predict that to be the "correct" solution file if we find the project name
+    for _, file_path in ipairs(sln_files) do
         local file = io.open(file_path, "r")
 
         if not file then
@@ -12,62 +73,12 @@ local function get_filepath_containing_string(file_paths, search_string)
         local content = file:read("*a")
         file:close()
 
-        if content:find(search_string, 1, true) then
+        if content:find(csproj_filename, 1, true) then
             return file_path
         end
     end
 
     return nil
-end
-
-local M = {}
-
----@class RoslynNvimDirectoryWithFiles
----@field directory string
----@field files string[]
-
----Gets the directory containing `ext`, and all the files in that directory with `ext`
----@param buffer integer
----@param ext "sln" | "csproj"
----@return RoslynNvimDirectoryWithFiles?
-function M.get_directory_with_files(buffer, ext)
-    local directory = vim.fs.root(buffer, function(name)
-        return name:match(string.format("%%.%s$", ext)) ~= nil
-    end)
-
-    if not directory then
-        return nil
-    end
-
-    -- Probably redundant check, but doesn't hurt
-    local files = vim.fn.glob(vim.fs.joinpath(directory, string.format("*.%s", ext)), true, true)
-    if not files then
-        return nil
-    end
-
-    return {
-        directory = directory,
-        files = files,
-    }
-end
-
---- Find a path to sln file that is likely to be the one that the current buffer
---- belongs to. Ability to predict the right sln file automates the process of starting
---- LSP, without requiring the user to invoke CSTarget each time the solution is open.
---- The prediction assumes that the nearest csproj file (in one of parent dirs from buffer)
---- should be a part of the sln file that the user intended to open.
----@param buffer integer
----@param sln RoslynNvimDirectoryWithFiles
----@return string?
-function M.predict_sln_file(buffer, sln)
-    local csproj = M.get_directory_with_files(buffer, "csproj")
-    if not csproj or #csproj.files > 1 then
-        return nil
-    end
-
-    local csproj_filename = vim.fn.fnamemodify(csproj.files[1], ":t")
-
-    return get_filepath_containing_string(sln.files, csproj_filename)
 end
 
 return M


### PR DESCRIPTION
This makes a couple of changes:
- We only store a single known solution file. The reason for this, is that it seems to really not work with multiple solutions, and this is a bit more close to how vscode handles it (It seems like)
- Stop the server between changing targets with `CSTarget`
- Custom method for reusing the server if we have a solution (I have a project where I have multiple csproj-files that is not necessarily a child of where the solution file is. The current implementation makes this not work
-  Use BufEnter for the autocmd instead of `FileType`. If changing back and forth, it will not create a `CSTarget` user command with the `FileType` event. This is because this is only fired once per buffer.

In some cases, this also removes the notify of multiple solution files found. I sort of wish I could find a way to notify the user in a bit more cases. However, it might also be really overkill to notify everytime we create the user command for the buffer, since it might happen a lot if we are in a project with multiple solution files

I will use this for a little bit, and see if this breaks something. Doesn't look like it from initial testing😄 If anyone comes by this, feel free to comment