### PR TITLE
Add encoding parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ require("roslyn").setup({
     -- However, in `hacks.lua` I will also just don't start off any watchers, which seems to make the server
     -- a lot faster to initialize.
     filewatching = true,
+    offset_encoding = nil, -- add your preferred client offset_encoding here since on_init is overwritten
 })
 ```
 

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -114,6 +114,7 @@ local function lsp_start(pipe, root_dir, roslyn_config, on_init)
         end,
     }, config.handlers or {})
     config.on_init = function(client)
+        client.offset_encoding = roslyn_config.offset_encoding or client.offset_encoding
         on_init(client)
 
         local commands = require("roslyn.commands")
@@ -158,11 +159,13 @@ end
 
 ---@class InternalRoslynNvimConfig
 ---@field filewatching boolean
+---@field offset_encoding? string
 ---@field exe? string|string[]
 ---@field config vim.lsp.ClientConfig
 ---
 ---@class RoslynNvimConfig
 ---@field filewatching? boolean
+---@field offset_encoding? string
 ---@field exe? string|string[]
 ---@field config? vim.lsp.ClientConfig
 
@@ -246,6 +249,7 @@ function M.setup(config)
     ---@type InternalRoslynNvimConfig
     local default_config = {
         filewatching = true,
+        offset_encoding = nil,
         exe = nil,
         ---@diagnostic disable-next-line: missing-fields
         config = {},


### PR DESCRIPTION
Add the option to change the client's offset encoding. This is currently not possible as the on_init method is overwritten. 

This is needed because [neovim lsp throws an error with mixed LF, CRLF files](https://github.com/neovim/neovim/issues/19237). In the case of C#, it can happen without human error by using source generators, for example the [Godot](https://github.com/godotengine/godot) [generators](https://www.nuget.org/packages/GodotSharp.SourceGenerators/)

The only known workarounds (that I could find and test, at least) are to force the encoding to utf-8 or modify neovim's source code directly as mentioned in the issue linked above