### PR TITLE
Allow for user custom on_init, on_exit hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ require("roslyn").setup({
         --     - `name`
         --     - `cmd`
         --     - `root_dir`
-        --     - `on_init`
     },
     exe = {
         "dotnet",

--- a/lua/roslyn/commands.lua
+++ b/lua/roslyn/commands.lua
@@ -39,7 +39,7 @@ local function handle_fix_all_code_action(client, data)
                 vim.notify(err.message, vim.log.levels.ERROR)
             end
             if response and response.edit then
-                vim.lsp.util.apply_workspace_edit(response.edit, "utf-8")
+                vim.lsp.util.apply_workspace_edit(response.edit, client.offset_encoding)
             end
         end)
     end)
@@ -79,7 +79,7 @@ function M.nested_code_action(client)
                         vim.notify(err.message, vim.log.levels.ERROR)
                     end
                     if response and response.edit then
-                        vim.lsp.util.apply_workspace_edit(response.edit, "utf-8")
+                        vim.lsp.util.apply_workspace_edit(response.edit, client.offset_encoding)
                     end
                 end)
             end

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -109,7 +109,10 @@ local function lsp_start(pipe, root_dir, roslyn_config, on_init)
             return vim.NIL
         end,
     }, config.handlers or {})
-    config.on_init = function(client)
+    config.on_init = function(client, initialize_result)
+        if roslyn_config.config.on_init then
+            roslyn_config.config.on_init(client, initialize_result)
+        end
         on_init(client)
 
         local commands = require("roslyn.commands")
@@ -117,12 +120,15 @@ local function lsp_start(pipe, root_dir, roslyn_config, on_init)
         commands.nested_code_action(client)
     end
 
-    config.on_exit = function(_, _, _)
+    config.on_exit = function(code, signal, client_id)
         vim.g.roslyn_nvim_selected_solution = nil
         server.stop_server()
         vim.schedule(function()
             vim.notify("Roslyn server stopped", vim.log.levels.INFO)
         end)
+        if roslyn_config.config.on_exit then
+            roslyn_config.config.on_exit(code, signal, client_id)
+        end
     end
 
     vim.lsp.start(config, {


### PR DESCRIPTION
Allow for user custom on_init, on_exit hooks & fix encoding used for code actions

Supersedes https://github.com/seblj/roslyn.nvim/pull/35