### PR TITLE
Project initializing refactor

### DIFF
--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -172,7 +172,10 @@ local function wrap_roslyn(cmd, root_dir, roslyn_config, on_init)
 
     server.start_server(cmd, config, function(pipe_name)
         config.cmd = vim.lsp.rpc.connect(pipe_name)
-        server.start(config)
+        local client_id = vim.lsp.start(config)
+        if client_id then
+            server.save_server_object(client_id)
+        end
     end)
 end
 

--- a/lua/roslyn/server.lua
+++ b/lua/roslyn/server.lua
@@ -7,16 +7,6 @@ local _current_server_object = nil
 ---@type vim.SystemObj[]
 local _server_objects = {}
 
----@param bufnr (integer|nil) Buffer number to resolve. Defaults to current buffer
----@return integer bufnr
-local function resolve_bufnr(bufnr)
-    vim.validate({ bufnr = { bufnr, "n", true } })
-    if bufnr == nil or bufnr == 0 then
-        return vim.api.nvim_get_current_buf()
-    end
-    return bufnr
-end
-
 --- @param client vim.lsp.Client
 --- @param config vim.lsp.ClientConfig
 --- @return boolean
@@ -99,38 +89,9 @@ function M.stop_server(client_id)
     end
 end
 
-function M.start(config, opts)
-    opts = opts or {}
-    local reuse_client = opts.reuse_client or reuse_client_default
-    local bufnr = resolve_bufnr(opts.bufnr)
-
-    local all_clients = vim.lsp.get_clients()
-
-    for _, client in pairs(all_clients) do
-        if reuse_client(client, config) then
-            if vim.lsp.buf_attach_client(bufnr, client.id) then
-                _server_objects[client.id] = _current_server_object
-                return client.id
-            else
-                return nil
-            end
-        end
-    end
-
-    local client_id, err = vim.lsp.start_client(config)
-    if err then
-        if not opts.silent then
-            vim.notify(err, vim.log.levels.WARN)
-        end
-        return nil
-    end
-
-    if client_id and vim.lsp.buf_attach_client(bufnr, client_id) then
-        _server_objects[client_id] = _current_server_object
-        return client_id
-    end
-
-    return nil
+---@param client_id integer
+function M.save_server_object(client_id)
+    _server_objects[client_id] = _current_server_object
 end
 
 return M

--- a/lua/roslyn/server.lua
+++ b/lua/roslyn/server.lua
@@ -1,21 +1,56 @@
----@type string?
-local _pipe_name = nil
+---@type table<string, string>
+local _pipe_names = {}
+
 ---@type vim.SystemObj?
-local _server_object = nil
+local _current_server_object = nil
+
+---@type vim.SystemObj[]
+local _server_objects = {}
+
+---@param bufnr (integer|nil) Buffer number to resolve. Defaults to current buffer
+---@return integer bufnr
+local function resolve_bufnr(bufnr)
+    vim.validate({ bufnr = { bufnr, "n", true } })
+    if bufnr == nil or bufnr == 0 then
+        return vim.api.nvim_get_current_buf()
+    end
+    return bufnr
+end
+
+--- @param client vim.lsp.Client
+--- @param config vim.lsp.ClientConfig
+--- @return boolean
+local function reuse_client_default(client, config)
+    if client.name ~= config.name then
+        return false
+    end
+
+    if config.root_dir then
+        for _, dir in ipairs(client.workspace_folders or {}) do
+            -- note: do not need to check client.root_dir since that should be client.workspace_folders[1]
+            if config.root_dir == dir.name then
+                return true
+            end
+        end
+    end
+
+    return false
+end
 
 local M = {}
 
 ---@param cmd string[]
+---@param config vim.lsp.ClientConfig Configuration for the server.
 ---@param with_pipe_name fun(pipe_name: string): nil A function to execute after server start and pipe_name is known
-function M.start_server(cmd, with_pipe_name)
-    if _pipe_name then
-        with_pipe_name(_pipe_name)
-        return
+function M.start_server(cmd, config, with_pipe_name)
+    local all_clients = vim.lsp.get_clients()
+    for _, client in pairs(all_clients) do
+        if reuse_client_default(client, config) and _pipe_names[config.root_dir] then
+            return with_pipe_name(_pipe_names[config.root_dir])
+        end
     end
-    if _server_object then
-        return
-    end
-    _server_object = vim.system(cmd, {
+
+    _current_server_object = vim.system(cmd, {
         detach = not vim.uv.os_uname().version:find("Windows"),
         stdout = function(_, data)
             if not data then
@@ -34,7 +69,7 @@ function M.start_server(cmd, with_pipe_name)
             end
 
             -- Cache the pipe name so we only start roslyn once.
-            _pipe_name = pipe_name
+            _pipe_names[config.root_dir] = pipe_name
 
             vim.schedule(function()
                 with_pipe_name(pipe_name)
@@ -47,16 +82,55 @@ function M.start_server(cmd, with_pipe_name)
             end
         end,
     }, function()
-        _pipe_name = nil
+        _pipe_names[config.root_dir] = nil
     end)
 end
 
-function M.stop_server()
-    if _server_object then
-        _server_object:kill(9)
+function M.stop_server(client_id)
+    local client = vim.lsp.get_client_by_id(client_id)
+
+    local server_object = _server_objects[client_id]
+    if server_object then
+        server_object:kill(9)
     end
-    _pipe_name = nil
-    _server_object = nil
+
+    if client then
+        _pipe_names[client.root_dir] = nil
+    end
+end
+
+function M.start(config, opts)
+    opts = opts or {}
+    local reuse_client = opts.reuse_client or reuse_client_default
+    local bufnr = resolve_bufnr(opts.bufnr)
+
+    local all_clients = vim.lsp.get_clients()
+
+    for _, client in pairs(all_clients) do
+        if reuse_client(client, config) then
+            if vim.lsp.buf_attach_client(bufnr, client.id) then
+                _server_objects[client.id] = _current_server_object
+                return client.id
+            else
+                return nil
+            end
+        end
+    end
+
+    local client_id, err = vim.lsp.start_client(config)
+    if err then
+        if not opts.silent then
+            vim.notify(err, vim.log.levels.WARN)
+        end
+        return nil
+    end
+
+    if client_id and vim.lsp.buf_attach_client(bufnr, client_id) then
+        _server_objects[client_id] = _current_server_object
+        return client_id
+    end
+
+    return nil
 end
 
 return M


### PR DESCRIPTION
I might not merge this yet, but I will open it for now if someone comes along and wants to see it, and I also think I will refactor this a bit.

Mostly, this is a bit of a change in how it decides to attach to either a project or a solution.

- It will attach to csproj if neovim is opened where a solution file does not exist in cwd or in any subdirectories.
- It wil however only do this if the file opened from neovim is actually in any subdirectories.
    - If not, then it will fallback to the previous way of deciding


Also; There is some new logic for deciding if we should reuse an instance of the server or create a new one. `vim.lsp.start` cannot do this without something wrapping it, since the server doesn't support starting it with the ways that is communicated in the spec. I am still a bit unsure if I want to do this and if this even works as intended.

I might also split this into two PR's, as I definitely will want the ability to attach to a single project when there is a sln file in a parent directory of the cwd. Currently this is impossible, and it is kind of annoying when there is a single standalone project in any subdirectories of the directory containing the solution file