### PR TITLE
fix: properly spawn new language server if needed

### DIFF
--- a/lua/roslyn/server.lua
+++ b/lua/roslyn/server.lua
@@ -1,21 +1,46 @@
----@type string?
-local _pipe_name = nil
+---@type table<string, string>
+local _pipe_names = {}
+
 ---@type vim.SystemObj?
-local _server_object = nil
+local _current_server_object = nil
+
+---@type vim.SystemObj[]
+local _server_objects = {}
+
+--- @param client vim.lsp.Client
+--- @param config vim.lsp.ClientConfig
+--- @return boolean
+local function reuse_client_default(client, config)
+    if client.name ~= config.name then
+        return false
+    end
+
+    if config.root_dir then
+        for _, dir in ipairs(client.workspace_folders or {}) do
+            -- note: do not need to check client.root_dir since that should be client.workspace_folders[1]
+            if config.root_dir == dir.name then
+                return true
+            end
+        end
+    end
+
+    return false
+end
 
 local M = {}
 
 ---@param cmd string[]
+---@param config vim.lsp.ClientConfig Configuration for the server.
 ---@param with_pipe_name fun(pipe_name: string): nil A function to execute after server start and pipe_name is known
-function M.start_server(cmd, with_pipe_name)
-    if _pipe_name then
-        with_pipe_name(_pipe_name)
-        return
+function M.start_server(cmd, config, with_pipe_name)
+    local all_clients = vim.lsp.get_clients()
+    for _, client in pairs(all_clients) do
+        if reuse_client_default(client, config) and _pipe_names[config.root_dir] then
+            return with_pipe_name(_pipe_names[config.root_dir])
+        end
     end
-    if _server_object then
-        return
-    end
-    _server_object = vim.system(cmd, {
+
+    _current_server_object = vim.system(cmd, {
         detach = not vim.uv.os_uname().version:find("Windows"),
         stdout = function(_, data)
             if not data then
@@ -34,7 +59,7 @@ function M.start_server(cmd, with_pipe_name)
             end
 
             -- Cache the pipe name so we only start roslyn once.
-            _pipe_name = pipe_name
+            _pipe_names[config.root_dir] = pipe_name
 
             vim.schedule(function()
                 with_pipe_name(pipe_name)
@@ -47,16 +72,26 @@ function M.start_server(cmd, with_pipe_name)
             end
         end,
     }, function()
-        _pipe_name = nil
+        _pipe_names[config.root_dir] = nil
     end)
 end
 
-function M.stop_server()
-    if _server_object then
-        _server_object:kill(9)
+function M.stop_server(client_id)
+    local client = vim.lsp.get_client_by_id(client_id)
+
+    local server_object = _server_objects[client_id]
+    if server_object then
+        server_object:kill(9)
     end
-    _pipe_name = nil
-    _server_object = nil
+
+    if client then
+        _pipe_names[client.root_dir] = nil
+    end
+end
+
+---@param client_id integer
+function M.save_server_object(client_id)
+    _server_objects[client_id] = _current_server_object
 end
 
 return M

--- a/lua/roslyn/server.lua
+++ b/lua/roslyn/server.lua
@@ -11,20 +11,9 @@ local _server_objects = {}
 --- @param config vim.lsp.ClientConfig
 --- @return boolean
 local function reuse_client_default(client, config)
-    if client.name ~= config.name then
-        return false
-    end
-
-    if config.root_dir then
-        for _, dir in ipairs(client.workspace_folders or {}) do
-            -- note: do not need to check client.root_dir since that should be client.workspace_folders[1]
-            if config.root_dir == dir.name then
-                return true
-            end
-        end
-    end
-
-    return false
+    return vim.iter(client.workspace_folders or {}):any(function(it)
+        return config.root_dir == it.name
+    end)
 end
 
 local M = {}
@@ -33,7 +22,7 @@ local M = {}
 ---@param config vim.lsp.ClientConfig Configuration for the server.
 ---@param with_pipe_name fun(pipe_name: string): nil A function to execute after server start and pipe_name is known
 function M.start_server(cmd, config, with_pipe_name)
-    local all_clients = vim.lsp.get_clients()
+    local all_clients = vim.lsp.get_clients({ name = "roslyn" })
     for _, client in pairs(all_clients) do
         if reuse_client_default(client, config) and _pipe_names[config.root_dir] then
             return with_pipe_name(_pipe_names[config.root_dir])


### PR DESCRIPTION
This should properly spawn new servers if a different project is opened in the same neovim session.

Previously, it would just use the already selected sln.

This should change that so that if I am attached to the solution

`~/foo/foo.sln`, and I suddenly open a file in a totally different project
`~/bar/bar.sln`.

This will now start a new server instead of trying to reuse the same one.
Reusing the same one didn't seem to work properly.

This should only be for edge cases where someone might jump back and forth between projects like this, but I am still not 100% sure that I want this. I will be using this for a little while and see if I have some issues with it. Feel free to comment if you stumble across this, and let me know your opinion!