### PR TITLE
perf: changing the way to search for .csproj and .sln files to reduce the number of analyzed files

### DIFF
--- a/lua/roslyn/slnutils.lua
+++ b/lua/roslyn/slnutils.lua
@@ -57,7 +57,9 @@ function M.try_get_csproj_files()
 
     local csprojs = find_files_with_extension(cwd, ".csproj")
 
-    if #csprojs > 0 then
+    local solutions = find_files_with_extension(cwd, ".sln")
+
+    if #csprojs > 0 and #solutions == 0 then
         return {
             directory = cwd,
             files = csprojs,

--- a/lua/roslyn/slnutils.lua
+++ b/lua/roslyn/slnutils.lua
@@ -61,7 +61,7 @@ end
 ---
 --- @return RoslynNvimDirectoryWithFiles? A table containing the directory path and a list of found `.csproj` files, or `nil` if none are found.
 function M.try_get_csproj_files()
-    local cwd = vim.fn.getcwd()
+    local cwd = assert(vim.uv.cwd())
 
     local csprojs = {}
 

--- a/lua/roslyn/slnutils.lua
+++ b/lua/roslyn/slnutils.lua
@@ -1,26 +1,18 @@
 local M = {}
 
---- Recursively searches for files with a specific extension within a directory range.
---- The search starts at the 'from' directory and continues until the 'to' directory.
+--- Searches for files with a specific extension within a directory.
 --- Only files matching the provided extension are returned.
 ---
---- @param from string The starting directory path for the search.
---- @param to string? The ending directory path to stop the search. (Cannot contain '/' in the end)
+--- @param dir string The directory path for the search.
 --- @param extension string The file extension to look for (e.g., ".sln").
 ---
 --- @return string[] List of file paths that match the specified extension.
-local function find_files_with_extension(from, to, extension)
+local function find_files_with_extension(dir, extension)
     local matches = {}
 
-    for dir in vim.fs.parents(from) do
-        if dir == to then
-            break
-        end
-
-        for entry, type in vim.fs.dir(dir) do
-            if type == "file" and vim.endswith(entry, extension) then
-                matches[#matches + 1] = vim.fs.normalize(vim.fs.joinpath(dir, entry))
-            end
+    for entry, type in vim.fs.dir(dir) do
+        if type == "file" and vim.endswith(entry, extension) then
+            matches[#matches + 1] = vim.fs.normalize(vim.fs.joinpath(dir, entry))
         end
     end
 
@@ -63,13 +55,7 @@ end
 function M.try_get_csproj_files()
     local cwd = assert(vim.uv.cwd())
 
-    local csprojs = {}
-
-    for entry, entry_type in vim.fs.dir(cwd) do
-        if entry_type == "file" and vim.endswith(entry, ".csproj") then
-            csprojs[#csprojs + 1] = vim.fs.normalize(vim.fs.joinpath(cwd, entry))
-        end
-    end
+    local csprojs = find_files_with_extension(cwd, ".csproj")
 
     if #csprojs > 0 then
         return {
@@ -95,7 +81,7 @@ function M.get_solution_files(buffer)
         return nil
     end
 
-    return find_files_with_extension(vim.api.nvim_buf_get_name(buffer), vim.fs.basename(directory), ".sln")
+    return find_files_with_extension(directory, ".sln")
 end
 
 --- Find a path to sln file that is likely to be the one that the current buffer


### PR DESCRIPTION
fixes: #45

This changes the behaviour since we would stop looking for .csproj and .sln files for all the directories inside the root directory. I don't know if this is so important but, if it is, we could provide two ways of search (broad and narrow) in some kind of option (I think that narrow would be the better default).

If there are anything that needs change, please let me know.