### PR TITLE
feat: add option for broad sln search

### DIFF
--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -172,12 +172,14 @@ end
 ---@field exe? string|string[]
 ---@field config vim.lsp.ClientConfig
 ---@field choose_sln? fun(solutions: string[]): string?
----
+---@field broad_search boolean
+
 ---@class RoslynNvimConfig
 ---@field filewatching? boolean
 ---@field exe? string|string[]
 ---@field config? vim.lsp.ClientConfig
 ---@field choose_sln? fun(solutions: string[]): string?
+---@field broad_search? boolean
 
 local M = {}
 
@@ -263,6 +265,7 @@ function M.setup(config)
         ---@diagnostic disable-next-line: missing-fields
         config = {},
         choose_sln = nil,
+        broad_search = false,
     }
 
     local roslyn_config = vim.tbl_deep_extend("force", default_config, config or {})
@@ -293,7 +296,7 @@ function M.setup(config)
                 return start_with_projects(cmd, opt.buf, csproj_files, roslyn_config)
             end
 
-            local sln_files = utils.get_solution_files(opt.buf)
+            local sln_files = utils.get_solution_files(opt.buf, roslyn_config.broad_search)
             if sln_files and not vim.tbl_isempty(sln_files) then
                 return start_with_solution(opt.buf, cmd, sln_files, roslyn_config, on_init_sln)
             end

--- a/lua/roslyn/slnutils.lua
+++ b/lua/roslyn/slnutils.lua
@@ -72,9 +72,15 @@ end
 ---Find the solution file from the current buffer.
 ---Recursively see if we have any other solution files, to potentially
 ---give the user an option to choose which solution file to use
+
+---Broad search will search from the root directory and down to potentially
+---find sln files that is not in the root directory.
+---This could potentially be slow, so by default it is off
+
 ---@param buffer integer
+---@param broad_search boolean
 ---@return string[]?
-function M.get_solution_files(buffer)
+function M.get_solution_files(buffer, broad_search)
     local directory = vim.fs.root(buffer, function(name)
         return name:match("%.sln$") ~= nil
     end)
@@ -83,7 +89,13 @@ function M.get_solution_files(buffer)
         return nil
     end
 
-    return find_files_with_extension(directory, ".sln")
+    if broad_search then
+        return vim.fs.find(function(name, _)
+            return name:match("%.sln$")
+        end, { type = "file", limit = math.huge, path = directory })
+    else
+        return find_files_with_extension(directory, ".sln")
+    end
 end
 
 --- Find a path to sln file that is likely to be the one that the current buffer


### PR DESCRIPTION
I now realise I don't think it was broad search for solution file that was slow, and it was really just trying to get csproj file in a really bad way. The current way of trying to attach to only a single project seems to be just what I need at least. (I don't even remember why I made it so complicated in the beginning)

I am kind of tempted to not have this optional and just have this as the only default, but it was so little code for an option, so I will probably keep this opt-in until someone potentially argues that this should be the default.