### PR TITLE
feat: roslyn initializing spinner

### DIFF
--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -72,6 +72,8 @@ end
 ---@param roslyn_config InternalRoslynNvimConfig
 ---@param on_init fun(client: vim.lsp.Client)
 local function lsp_start(cmd, bufnr, root_dir, roslyn_config, on_init)
+    local spinner = require("roslyn.spinner").new()
+    spinner:start_spinner("Initializing roslyn client")
     local config = vim.deepcopy(roslyn_config.config)
     config.name = "roslyn"
     config.root_dir = root_dir
@@ -81,7 +83,7 @@ local function lsp_start(cmd, bufnr, root_dir, roslyn_config, on_init)
             roslyn_config.filewatching
         ),
         ["workspace/projectInitializationComplete"] = function(_, _, ctx)
-            vim.notify("Roslyn project initialization complete", vim.log.levels.INFO)
+            spinner:stop_spinner("Roslyn project initialization complete")
 
             local buffers = vim.lsp.get_buffers_by_client_id(ctx.client_id)
             for _, buf in ipairs(buffers) do
@@ -257,7 +259,6 @@ end
 ---@param roslyn_config InternalRoslynNvimConfig
 local function start_with_projects(cmd, bufnr, csproj, roslyn_config)
     lsp_start(cmd, bufnr, csproj.directory, roslyn_config, function(client)
-        vim.notify("Initializing Roslyn client for projects", vim.log.levels.INFO)
         client.notify("project/open", {
             projects = vim.tbl_map(function(file)
                 return vim.uri_from_fname(file)
@@ -289,7 +290,6 @@ function M.setup(config)
     ---@param target string
     local function on_init_sln(target)
         return function(client)
-            vim.notify("Initializing Roslyn client for " .. target, vim.log.levels.INFO)
             client.notify("solution/open", {
                 solution = vim.uri_from_fname(target),
             })

--- a/lua/roslyn/spinner.lua
+++ b/lua/roslyn/spinner.lua
@@ -1,0 +1,79 @@
+---@class Spinner
+local M = {}
+M.__index = M
+
+---Spinner symbol presets
+M.spinner_presets = {
+    default = { "⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷" },
+    lines = { "-", "\\", "|", "/" },
+    dots = { ".", "..", "...", "...." },
+    arrows = { "→", "↘", "↓", "↙", "←", "↖", "↑", "↗" },
+}
+
+---Creates a new spinner instance.
+---@return Spinner
+function M.new()
+    ---@class Spinner
+    local self = setmetatable({}, M)
+    self.spinner_symbols = M.spinner_presets.default ---@type string[] The current spinner symbols
+    self.spinner_index = 1 ---@type integer Current index of the spinner symbol
+    self.spinner_timer = nil
+    self.notify_id = nil ---@type integer|nil Notification ID to replace in vim.notify
+    return self
+end
+
+---Updates the spinner notification.
+---@param pendingText string The text to display while the spinner is running.
+function M:update_spinner(pendingText)
+    if self.spinner_timer then
+        self.notify_id =
+            vim.notify(pendingText .. " " .. self.spinner_symbols[self.spinner_index], vim.log.levels.INFO, {
+                title = "Progress",
+                replace = self.notify_id,
+            })
+        self.spinner_index = (self.spinner_index % #self.spinner_symbols) + 1
+    end
+end
+
+---Starts the spinner with a given pending message and optional symbol preset.
+---@param pendingText string The message to display while the spinner is running.
+---@param preset "dots"|"arrows"|nil Optional spinner symbol preset to use.
+function M:start_spinner(pendingText, preset)
+    if preset and M.spinner_presets[preset] then
+        self.spinner_symbols = M.spinner_presets[preset]
+    else
+        self.spinner_symbols = M.spinner_presets.default
+    end
+
+    if not self.spinner_timer then
+        self.spinner_timer = vim.loop.new_timer()
+        self.spinner_timer:start(
+            0,
+            300,
+            vim.schedule_wrap(function()
+                self:update_spinner(pendingText)
+            end)
+        )
+    end
+end
+
+---Stops the spinner and displays the finish message.
+---@param finishText string The message to display when the spinner stops.
+---@param level integer | nil One of the values from |vim.log.levels|.
+function M:stop_spinner(finishText, level)
+    if not level then
+        level = vim.log.levels.INFO
+    end
+    if self.spinner_timer then
+        self.spinner_timer:stop()
+        self.spinner_timer:close()
+        self.spinner_timer = nil
+        vim.notify(finishText, level, {
+            title = "Progress",
+            replace = self.notify_id,
+        })
+        self.notify_id = nil
+    end
+end
+
+return M


### PR DESCRIPTION
Today when opening a .cs file the roslyn lsp will initialize. First starting with a notification saying `Initializing Roslyn client for ...` then a notification saying `Roslyn project initialization complete`. In my projects and I suspect most projects these messages overlap causing 2 notifications to be active at the same time. This isnt a big deal in any regard but has annoyed me enough times to make this PR. I know roslyn lsp doesnt support progress messages so this was the best I could do. 

I purposely didnt make an issue about this upfront because this is highly subjective, but if you like it feel free to merge it. Otherwise just close it