### PR TITLE
refator: FileType Autocmd and path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ The plugin comes with the following defaults:
         "dotnet",
         vim.fs.joinpath(vim.fn.stdpath("data"), "roslyn", "Microsoft.CodeAnalysis.LanguageServer.dll"),
     },
+    extra_args = {
+        "--logLevel=Information", "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path())
+    },
+  --[[
+  -- extra_args can be used to pass additional flags to the language server
+    ]]
 
     -- NOTE: Set `filewatching` to false if you experience performance problems.
     -- Defaults to true, since turning it off is a hack.

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ The plugin comes with the following defaults:
         "dotnet",
         vim.fs.joinpath(vim.fn.stdpath("data"), "roslyn", "Microsoft.CodeAnalysis.LanguageServer.dll"),
     },
-    extra_args = {
+    args = {
         "--logLevel=Information", "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path())
     },
   --[[
-  -- extra_args can be used to pass additional flags to the language server
+  -- args can be used to pass additional flags to the language server
     ]]
 
     -- NOTE: Set `filewatching` to false if you experience performance problems.

--- a/lua/roslyn/commands.lua
+++ b/lua/roslyn/commands.lua
@@ -28,7 +28,7 @@ local subcommand_tbl = {
                 vim.schedule_wrap(function()
                     if client.is_stopped() then
                         for _, buffer in ipairs(attached_buffers) do
-                            vim.api.nvim_exec_autocmds("BufEnter", { group = "Roslyn", buffer = buffer })
+                            vim.api.nvim_exec_autocmds("FileType", { group = "Roslyn", buffer = buffer })
                         end
                     end
 

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -87,6 +87,8 @@ local function lsp_start(cmd, bufnr, root_dir, roslyn_config, on_init)
             for _, buf in ipairs(buffers) do
                 vim.lsp.util._refresh("textDocument/diagnostic", { bufnr = buf })
             end
+
+            vim.api.nvim_exec_autocmds("User", { pattern = "RoslynInitialized", modeline = false })
         end,
         ["workspace/_roslyn_projectHasUnresolvedDependencies"] = function()
             vim.notify("Detected missing dependencies. Run dotnet restore command.", vim.log.levels.ERROR)

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -144,43 +144,34 @@ local function lsp_start(cmd, bufnr, root_dir, roslyn_config, on_init)
 end
 
 ---@param exe string|string[]
+---@param extra_args string[]
 ---@return string[]
-local function get_cmd(exe)
-    local default_lsp_args =
-        { "--logLevel=Information", "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path()) }
+local function get_cmd(exe, extra_args)
     local mason_installation = get_mason_installation()
     local mason_exists = vim.fn.executable(mason_installation) == 1
 
-    if mason_exists then
-        local base_mason = vim.list_extend({ mason_installation }, default_lsp_args)
-        if type(exe) == "string" then
-            return vim.list_extend(base_mason, { exe })
-        elseif type(exe) == "table" then
-            return vim.list_extend(base_mason, vim.deepcopy(exe))
-        else
-            return base_mason
-        end
+    if type(exe) == "string" then
+        return vim.list_extend({ exe }, extra_args)
+    elseif type(exe) == "table" then
+        return vim.list_extend(vim.deepcopy(exe), extra_args)
+    elseif mason_exists then
+        return vim.list_extend({ mason_installation }, extra_args)
     else
-        if type(exe) == "string" then
-            return vim.list_extend({ exe }, default_lsp_args)
-        elseif type(exe) == "table" then
-            return vim.list_extend(vim.deepcopy(exe), default_lsp_args)
-        else
-            return vim.list_extend({
-                "dotnet",
-                vim.fs.joinpath(
-                    vim.fn.stdpath("data") --[[@as string]],
-                    "roslyn",
-                    "Microsoft.CodeAnalysis.LanguageServer.dll"
-                ),
-            }, default_lsp_args)
-        end
+        return vim.list_extend({
+            "dotnet",
+            vim.fs.joinpath(
+                vim.fn.stdpath("data") --[[@as string]],
+                "roslyn",
+                "Microsoft.CodeAnalysis.LanguageServer.dll"
+            ),
+        }, extra_args)
     end
 end
 
 ---@class InternalRoslynNvimConfig
 ---@field filewatching boolean
 ---@field exe? string|string[]
+---@field extra_args? string[]
 ---@field config vim.lsp.ClientConfig
 ---@field choose_sln? fun(solutions: string[]): string?
 ---@field broad_search boolean
@@ -188,6 +179,7 @@ end
 ---@class RoslynNvimConfig
 ---@field filewatching? boolean
 ---@field exe? string|string[]
+---@field extra_args? string[]
 ---@field config? vim.lsp.ClientConfig
 ---@field choose_sln? fun(solutions: string[]): string?
 ---@field broad_search? boolean
@@ -285,6 +277,7 @@ function M.setup(config)
     local default_config = {
         filewatching = true,
         exe = nil,
+        extra_args = { "--logLevel=Information", "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path()) },
         ---@diagnostic disable-next-line: missing-fields
         config = {},
         choose_sln = nil,
@@ -294,7 +287,7 @@ function M.setup(config)
     local roslyn_config = vim.tbl_deep_extend("force", default_config, config or {})
     roslyn_config.config.capabilities = get_extendend_capabilities(roslyn_config)
 
-    local cmd = get_cmd(roslyn_config.exe)
+    local cmd = get_cmd(roslyn_config.exe, roslyn_config.extra_args)
 
     ---@param target string
     local function on_init_sln(target)


### PR DESCRIPTION
Problem:
* Autocmd: Using the BufRead autocmd means that the buffer must be focused in order to attach the LSP. As part of the integration with rzls for Razor support a virtual buffer is opened headlessly. This means that the LSP does not attach until the user BufEnters
* Lsp Cmd: Currenly it was not possible to add extra flags to the LSP start when using a mason installation.

Solution:
* Autocmd: Change to FileType Autocmd
* Lsp Cmd: Add wrapper to allow extension of Mason supplied path with either a table of a string of arguments