### PR TITLE
feat: option to disallow project initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ The plugin comes with the following defaults:
     --     end)
     -- end
     choose_sln = nil,
+    
+    -- Set allow_csproj_for_sln_swap to false to prevent projects from loading after a solution has been loaded. 
+    -- Consider this structure where both project1 and project2 are a part of the solution:
+    --
+    --      - Folder A
+    --          - Solution.sln
+    --          - Project1.sln
+    --      - Folder B
+    --          - Project2.sln
+    --
+    -- By default, when opening a file in folder B the LSP will start project2 as standalone a project. This means
+    -- jumping from Project2 to Project1 will not be possible and another LSP server will be started unnecessarily.
+    -- Setting this allow_csproj_for_sln_swap to false will prevent prevent this. 
+    allow_csproj_for_sln_swap = true,
 })
 ```
 

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -171,6 +171,7 @@ end
 ---@field config vim.lsp.ClientConfig
 ---@field choose_sln? fun(solutions: string[]): string?
 ---@field broad_search boolean
+---@field allow_csproj_for_sln_swap boolean
 
 ---@class RoslynNvimConfig
 ---@field filewatching? boolean
@@ -179,6 +180,7 @@ end
 ---@field config? vim.lsp.ClientConfig
 ---@field choose_sln? fun(solutions: string[]): string?
 ---@field broad_search? boolean
+---@field allow_csproj_for_sln_swap? boolean
 
 local M = {}
 
@@ -290,6 +292,7 @@ function M.setup(config)
         config = {},
         choose_sln = nil,
         broad_search = false,
+        allow_csproj_for_sln_swap = true,
     }
 
     local roslyn_config = vim.tbl_deep_extend("force", default_config, config or {})
@@ -316,7 +319,10 @@ function M.setup(config)
             end
 
             commands.create_roslyn_commands()
-            local csproj_files = utils.try_get_csproj_files()
+            local allow_projects = not vim.g.roslyn_nvim_selected_solution
+                or roslyn_config.allow_csproj_for_sln_swap ~= false
+
+            local csproj_files = allow_projects and utils.try_get_csproj_files()
             if csproj_files then
                 return start_with_projects(cmd, opt.buf, csproj_files, roslyn_config)
             end
@@ -326,7 +332,7 @@ function M.setup(config)
                 return start_with_solution(opt.buf, cmd, sln_files, roslyn_config, on_init_sln)
             end
 
-            local csproj = utils.get_project_files(opt.buf)
+            local csproj = allow_projects and utils.get_project_files(opt.buf)
             if csproj then
                 return start_with_projects(cmd, opt.buf, csproj, roslyn_config)
             end


### PR DESCRIPTION
This provides an option to disable initializing projects when a solution is already loaded. Reason for this is the project structure described in the Readme file. Currently it prevents me from jumping from a project that is outside the solution directory to projects inside it.

By default it will not alter the behaviour but will give an option to handle this scenario, which has been my only hiccup in an otherwise great experience. If you need further explanation on this let me know.