### PR TITLE
fix: roslyn doesn't attach to cs buffer when .sln is not present

### DIFF
--- a/lua/roslyn/sln/utils.lua
+++ b/lua/roslyn/sln/utils.lua
@@ -41,17 +41,23 @@ function M.root_dir(buffer, broad_search)
         return name:match("%.csproj$") ~= nil
     end)
 
-    if not sln or not csproj then
+    if not sln and not csproj then
         return {}
     end
 
     local projects = csproj and { files = find_files_with_extension(csproj, ".csproj"), directory = csproj } or nil
 
+    if not sln then
+        return {
+            solutions = nil,
+            projects = projects,
+        }
+    end
+
     if broad_search then
         local solutions = vim.fs.find(function(name, _)
             return name:match("%.sln$")
         end, { type = "file", limit = math.huge, path = sln })
-
         return {
             solutions = solutions,
             projects = projects,


### PR DESCRIPTION
The condition `not sln or not csproj` in sln.utils.root_dir was causing roslyn not to attach to cs buffer if one of .csproj or .sln was not found via `vim.fs.root_dir`

This behavior was introduced relatively recently in d121ca7d067c9b25a09990ccebb8eaa11710efbf

The fix updates the condition to allow for only one of these being found (the rest of the code already seems to account for it). After updating the condition, find_files_with_extension(sln, ".sln") was breaking as well, so I wrapped those calls in their own separate conditions based on if .csproj or .sln root directories were found.

Existing github issue: #87