### PR TITLE
feat: send last textDocument/diagnostic id

### DIFF
--- a/lua/roslyn/config.lua
+++ b/lua/roslyn/config.lua
@@ -76,6 +76,7 @@ local roslyn_config = {
     args = { "--logLevel=Information", "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path()) },
     ---@diagnostic disable-next-line: missing-fields
     config = {
+        handlers = {},
         capabilities = default_capabilities(),
     },
     choose_sln = nil,


### PR DESCRIPTION
Related to: https://github.com/seblj/roslyn.nvim/issues/93

Tested:
NVIM v0.10.2
NVIM v0.11.0-dev-1287+g8f84167c30
Custom on attach in the configuration
Custom handler for "textDocument/diagnostic" in the configuration

Unfortunately it seems 0.10 and 0.11 need slightly different implementations. Although from what I understand, 0.11 version should work in 0.10,  it doesn't. It receives a table instead of the method name and other parameters are received wrong too. 

Note: I'm not sure what are the situations when the received handler from the request method is not nil, it looks like even with a custom handler for textDocument/diagnostic it receives nil. 