### PR TITLE
Fix multiple csprojs 

### DIFF
--- a/lua/roslyn/sln/api.lua
+++ b/lua/roslyn/sln/api.lua
@@ -31,15 +31,13 @@ end
 
 ---Checks if a project is part of a solution or not
 ---@param solution string
----@param projects string[] Full path to the csproj files
+---@param project string Full path to the csproj file
 ---@return boolean
-function M.exists_in_solution(solution, projects)
-    local projectsInSln = M.projects(solution)
+function M.exists_in_solution(solution, project)
+    local projects = M.projects(solution)
 
-    return vim.iter(projectsInSln):find(function(pSln)
-        return vim.iter(projects):find(function(p)
-            return p == pSln
-        end) ~= nil
+    return vim.iter(projects):find(function(it)
+        return it == project
     end) ~= nil
 end
 

--- a/lua/roslyn/sln/api.lua
+++ b/lua/roslyn/sln/api.lua
@@ -31,13 +31,15 @@ end
 
 ---Checks if a project is part of a solution or not
 ---@param solution string
----@param project string Full path to the csproj file
+---@param projects string[] Full path to the csproj files
 ---@return boolean
-function M.exists_in_solution(solution, project)
-    local projects = M.projects(solution)
+function M.exists_in_solution(solution, projects)
+    local projectsInSln = M.projects(solution)
 
-    return vim.iter(projects):find(function(it)
-        return it == project
+    return vim.iter(projectsInSln):find(function(pSln)
+        return vim.iter(projects):find(function(p)
+            return p == pSln
+        end) ~= nil
     end) ~= nil
 end
 

--- a/lua/roslyn/sln/utils.lua
+++ b/lua/roslyn/sln/utils.lua
@@ -85,7 +85,7 @@ function M.predict_sln_file(root)
             if config.ignore_sln and config.ignore_sln(it) then
                 return false
             end
-            return (not root.projects or require("roslyn.sln.api").exists_in_solution(it, root.projects.files[1]))
+            return (not root.projects or require("roslyn.sln.api").exists_in_solution(it, root.projects.files))
         end)
         :totable()
 

--- a/lua/roslyn/sln/utils.lua
+++ b/lua/roslyn/sln/utils.lua
@@ -81,11 +81,14 @@ function M.predict_sln_file(root)
 
     local config = require("roslyn.config").get()
     local solutions = vim.iter(root.solutions)
-        :filter(function(it)
-            if config.ignore_sln and config.ignore_sln(it) then
+        :filter(function(solution)
+            if config.ignore_sln and config.ignore_sln(solution) then
                 return false
             end
-            return (not root.projects or require("roslyn.sln.api").exists_in_solution(it, root.projects.files))
+            return not root.projects
+                or vim.iter(root.projects.files):any(function(csproj_file)
+                    return require("roslyn.sln.api").exists_in_solution(solution, csproj_file)
+                end)
         end)
         :totable()
 


### PR DESCRIPTION
Currently at my work we have multiple csprojs, the actual csproj and then a backup like so

Backup.Project.csproj
Project.csproj

The Backup csproj is not referenced in the sln, not sure why this is the case but it is.

In this scenario predict_sln_file will just return nil and the lsp will spawn on the csproj only.
Not sure if my solution is the best, happy to try implement any better suggested solutions. I'm also a bit of a newbie when it comes to lua, neovim and contributing to open source, so any feedback is welcome