### PR TITLE
Add support for opening source generated documents

### DIFF
--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -10,6 +10,7 @@ local function valid_buffer(buf)
             or bufname:match("^[a-zA-Z]:")
             or bufname:match("^zipfile://")
             or bufname:match("^tarfile:")
+            or bufname:match("^roslyn%-source%-generated://")
         )
 end
 
@@ -26,7 +27,7 @@ function M.setup(config)
 
     vim.api.nvim_create_autocmd({ "FileType" }, {
         group = vim.api.nvim_create_augroup("Roslyn", { clear = true }),
-        pattern = "cs",
+        pattern = "cs", "roslyn-source-generated://*",
         callback = function(opt)
             if not valid_buffer(opt.buf) then
                 return

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -27,7 +27,7 @@ function M.setup(config)
 
     vim.api.nvim_create_autocmd({ "FileType" }, {
         group = vim.api.nvim_create_augroup("Roslyn", { clear = true }),
-        pattern = "cs", "roslyn-source-generated://*",
+        pattern = {"cs", "roslyn-source-generated://*"},
         callback = function(opt)
             if not valid_buffer(opt.buf) then
                 return

--- a/lua/roslyn/lsp.lua
+++ b/lua/roslyn/lsp.lua
@@ -92,30 +92,30 @@ function M.start(bufnr, root_dir, on_init)
     vim.api.nvim_create_autocmd({ "BufReadCmd" }, {
         pattern = "roslyn-source-generated://*",
         callback = function()
-            local uri = vim.fn.expand('<amatch>')
+            local uri = vim.fn.expand("<amatch>")
             local buf = vim.api.nvim_get_current_buf()
             vim.bo[buf].modifiable = true
             vim.bo[buf].swapfile = false
-            vim.bo[buf].buftype = 'nowrite'
+            vim.bo[buf].buftype = "nowrite"
             -- This triggers FileType event which should fire up the lsp client if not already running
-            vim.bo[buf].filetype = 'cs'
-            local client = vim.lsp.get_clients({ name = 'roslyn' })[1]
-            assert(client, 'Must have a `roslyn` client to load roslyn source generated file')
-    
+            vim.bo[buf].filetype = "cs"
+            local client = vim.lsp.get_clients({ name = "roslyn" })[1]
+            assert(client, "Must have a `roslyn` client to load roslyn source generated file")
+
             local content
             local function handler(err, result)
                 assert(not err, vim.inspect(err))
                 content = result.text
-                local normalized = string.gsub(content, '\r\n', '\n')
+                local normalized = string.gsub(content, "\r\n", "\n")
                 local source_lines = vim.split(normalized, "\n", { plain = true })
                 vim.api.nvim_buf_set_lines(buf, 0, -1, false, source_lines)
                 vim.bo[buf].modifiable = false
             end
-    
+
             local params = {
                 textDocument = {
-                    uri = uri
-                }
+                    uri = uri,
+                },
             }
 
             -- TODO: Change this to `client:request` when minimal version is `0.11`
@@ -123,8 +123,10 @@ function M.start(bufnr, root_dir, on_init)
             client.request("sourceGeneratedDocument/_roslyn_getText", params, handler, buf)
             -- Need to block. Otherwise logic could run that sets the cursor to a position
             -- that's still missing.
-            vim.wait(1000, function() return content ~= nil end)
-        end
+            vim.wait(1000, function()
+                return content ~= nil
+            end)
+        end,
     })
 
     server.start_server(bufnr, cmd, config)

--- a/lua/roslyn/lsp.lua
+++ b/lua/roslyn/lsp.lua
@@ -117,7 +117,9 @@ function M.start(bufnr, root_dir, on_init)
                     uri = uri
                 }
             }
-    
+
+            -- TODO: Change this to `client:request` when minimal version is `0.11`
+            ---@diagnostic disable-next-line: param-type-mismatch
             client.request("sourceGeneratedDocument/_roslyn_getText", params, handler, buf)
             -- Need to block. Otherwise logic could run that sets the cursor to a position
             -- that's still missing.


### PR DESCRIPTION
This PR adds support for opening and handling source generated documents. The reloading of open source generated documents is currently not implement, but should not be to hard to add.

The "BufReadCmd" callback is inspired by https://github.com/mfussenegger/nvim-jdtls/blob/master/lua/jdtls.lua#L1186 (including the vim.wait call).

The VsCode extension has also added support for source generated documents. (initial: https://github.com/dotnet/vscode-csharp/pull/7581, refresh support: https://github.com/dotnet/vscode-csharp/pull/7791, src location: `https://github.com/dotnet/vscode-csharp/blob/main/src/lsptoolshost/sourceGeneratedFilesContentProvider.ts)

Notes from manual testing:
The VsCode extension and this extension returns some times different results when executing the "go to reference" command.
E.g. In VsCode 3 references are found (`t.Print()`, `public partial Regex Print();` and `public partial global::System.Text.RegularExpressions.Regex Print() => global::System.Text.RegularExpressions.Generated.Print_0.Instance;`)
while this extension only returns 2 references (`public partial Regex Print();` and `public partial global::System.Text.RegularExpressions.Regex Print() => global::System.Text.RegularExpressions.Generated.Print_0.Instance;`).
But if the cursor is at the source generate method name, VsCode and this extension returns both 3 references.

I guess that this is not a direct problem with this PR, but rather some difference in the lsp client setup/lsp client implementation that lead to this behavior.

```csharp
var t = new Test2();
t.Print();
//  ^ place cursor here

public partial class Test2
{
	[GeneratedRegex("test")]
	public partial Regex Print();

	[GeneratedRegex("test2")]
	public partial Regex Print2();
}
```
---

For a better telescope support two thinks must be done:
1. register an autocmd handler:
```lua
vim.api.nvim_create_autocmd({ "User" }, {
	pattern = "TelescopePreviewerLoaded",
	callback = function(args)
		local putils = require("telescope.previewers.utils")
		if args.data ~= nil and args.data.bufname ~= nil and args.data.bufname:match("^roslyn%-source%-generated://") then
			putils.highlighter(args.buf, 'cs', {})
		end
	end
```

2. a slightly customized entry_maker function have to be provided:
```lua
local get_filename_fn = function()
	local bufnr_name_cache = {}
	return function(bufnr)
		bufnr = vim.F.if_nil(bufnr, 0)
		local c = bufnr_name_cache[bufnr]
		if c then
			return c
		end

		local n = vim.api.nvim_buf_get_name(bufnr)
		bufnr_name_cache[bufnr] = n
		return n
	end
end

local gen_from_quickfix_with_remotefile_support = function(opts)
	opts = opts or {}
	local show_line = vim.F.if_nil(opts.show_line, true)

	local utils = require("telescope.utils")
	local make_entry = require("telescope.make_entry")
	local hidden = utils.is_path_hidden(opts)

	local make_display = function(entry)
		-- optional customization
		local filename = entry.filename:match("^roslyn%-source%-generated://(.+)%?")
		if filename == nil then
			filename = entry.filename
		end

		local display_filename, path_style = utils.transform_path(opts, filename)

		local display_string = string.format("%s:%d:%d", display_filename, entry.lnum, entry.col)
		if hidden then
			display_string = string.format("%4d:%2d", entry.lnum, entry.col)
		end

		if show_line then
			local text = entry.text
			if opts.trim_text then
				text = vim.trim(text)
			end
			text = text:gsub(".* | ", "")
			display_string = display_string .. ":" .. text
		end

		return display_string, path_style
	end

	local get_filename = get_filename_fn()

	return function(entry)
		local filename = vim.F.if_nil(entry.filename, get_filename(entry.bufnr))

		-- required: Custom language server protocol extensions can result in servers sending URIs with custom schemes.
		-- These files are not stored on disk and we need to set the buffer number to show a preview for the buffer content.
		local bufnr = entry.bufnr
		if filename:match("^roslyn%-source%-generated://") then
			bufnr = vim.fn.bufnr(filename)
		end

		return make_entry.set_default_entry_mt({
			value = entry,
			ordinal = (not hidden and filename or "") .. " " .. entry.text,
			display = make_display,
			bufnr = bufnr,
			filename = filename,
			lnum = entry.lnum,
			col = entry.col,
			text = entry.text,
			start = entry.start,
			finish = entry.finish,
		}, opts)
	end
end

local opts = {
       entry_maker = gen_from_quickfix_with_remotefile_support()
}

require("telescope.builtin").lsp_references(opts)
```