### PR TITLE
Ignore bin and obj folders in broad solution search

### DIFF
--- a/lua/roslyn/sln/utils.lua
+++ b/lua/roslyn/sln/utils.lua
@@ -34,12 +34,12 @@ local function find_solutions(path)
     while #dirs > 0 do
         local dir = table.remove(dirs, 1)
 
-        for other, type in vim.fs.dir(dir) do
+        for other, fs_obj_type in vim.fs.dir(dir) do
             local name = vim.fs.joinpath(dir, other)
 
-            if type == "file" and name:match("%.sln$") then
+            if fs_obj_type == "file" and name:match("%.sln$") then
                 matches[#matches + 1] = vim.fs.normalize(name)
-            elseif type == 'directory' and not ignore_dir(name) then
+            elseif fs_obj_type == 'directory' and not ignore_dir(name) then
                 dirs[#dirs + 1] = name
             end
         end


### PR DESCRIPTION
Re perf comment

> I think we should try and combine some of the vim.fs.root and vim.fs.find methods in the utils.root method. I have gotten a couple of issues earlier about performance when finding the solution file, and this adds even more filesystem searching.

Speeds up my (very) large solution search by ~10x from ~2180ms to ~ 201ms.

I tried combining the `vim.fs.root` methods, and it works, but the perf gains are minimal so I will do as part of solution filter support if it becomes more measurable.

`find_solutions` is essentially a stripped down copy of `vim.fs.find`, the important bit being it skips based on `ignore_dir`. Currently, this just skips dotnet's `bin` and `obj` folders, but could be expanded for things like `.vs/`, `.vscode/`, `.idea/`, etc.