### PR TITLE
Support targeting solution filters

### DIFF
--- a/lua/roslyn/commands.lua
+++ b/lua/roslyn/commands.lua
@@ -62,7 +62,8 @@ local subcommand_tbl = {
 
             local roslyn_lsp = require("roslyn.lsp")
 
-            vim.ui.select(root.solutions or {}, { prompt = "Select target solution: " }, function(file)
+            local targets = vim.iter({ root.solutions, root.solution_filters }):flatten():totable()
+            vim.ui.select(targets or {}, { prompt = "Select target solution: " }, function(file)
                 if not file then
                     return
                 end

--- a/lua/roslyn/config.lua
+++ b/lua/roslyn/config.lua
@@ -7,6 +7,8 @@ local M = {}
 ---@field config vim.lsp.ClientConfig
 ---@field choose_sln? fun(solutions: string[]): string?
 ---@field ignore_sln? fun(solution: string): boolean
+---@field choose_target? fun(targets: string[]): string?
+---@field ignore_target? fun(target: string): boolean
 ---@field broad_search boolean
 ---@field lock_target boolean
 
@@ -17,6 +19,8 @@ local M = {}
 ---@field config? vim.lsp.ClientConfig
 ---@field choose_sln? fun(solutions: string[]): string?
 ---@field ignore_sln? fun(solution: string): boolean
+---@field choose_target? fun(targets: string[]): string?
+---@field ignore_target? fun(target: string): boolean
 ---@field broad_search? boolean
 ---@field lock_target? boolean
 
@@ -80,6 +84,8 @@ local roslyn_config = {
     },
     choose_sln = nil,
     ignore_sln = nil,
+    choose_target = nil,
+    ignore_target = nil,
     broad_search = false,
     lock_target = false,
 }
@@ -95,6 +101,28 @@ function M.setup(user_config)
 
     roslyn_config = vim.tbl_deep_extend("force", roslyn_config, user_config or {})
     roslyn_config.exe = type(roslyn_config.exe) == "string" and { roslyn_config.exe } or roslyn_config.exe
+
+    if roslyn_config.ignore_sln then
+        vim.notify(
+            "The `ignore_sln` option is deprecated. Please use `ignore_target` instead, which also receives solution filter files if present",
+            vim.log.levels.WARN,
+            { title = "roslyn.nvim" })
+
+        if not roslyn_config.ignore_target then
+            roslyn_config.ignore_target = roslyn_config.ignore_sln
+        end
+    end
+
+    if roslyn_config.choose_sln then
+        vim.notify(
+            "The `choose_sln` option is deprecated. Please use `choose_target` instead, which also receives solution filter files if present",
+            vim.log.levels.WARN,
+            { title = "roslyn.nvim" })
+
+        if not roslyn_config.choose_target then
+            roslyn_config.choose_target = roslyn_config.choose_sln
+        end
+    end
 
     -- HACK: Enable filewatching to later just not watch any files
     -- This is to not make the server watch files and make everything super slow in certain situations

--- a/lua/roslyn/config.lua
+++ b/lua/roslyn/config.lua
@@ -106,7 +106,8 @@ function M.setup(user_config)
         vim.notify(
             "The `ignore_sln` option is deprecated. Please use `ignore_target` instead, which also receives solution filter files if present",
             vim.log.levels.WARN,
-            { title = "roslyn.nvim" })
+            { title = "roslyn.nvim" }
+        )
 
         if not roslyn_config.ignore_target then
             roslyn_config.ignore_target = roslyn_config.ignore_sln
@@ -117,7 +118,8 @@ function M.setup(user_config)
         vim.notify(
             "The `choose_sln` option is deprecated. Please use `choose_target` instead, which also receives solution filter files if present",
             vim.log.levels.WARN,
-            { title = "roslyn.nvim" })
+            { title = "roslyn.nvim" }
+        )
 
         if not roslyn_config.choose_target then
             roslyn_config.choose_target = roslyn_config.choose_sln

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -56,14 +56,16 @@ function M.setup(config)
                         vim.notify(
                             "Multiple potential target files found. Use `:Roslyn target` to select a target.",
                             vim.log.levels.INFO,
-                            { title = "roslyn.nvim" })
+                            { title = "roslyn.nvim" }
+                        )
                         return
                     end
 
                     vim.notify(
                         "Multiple potential target files found. Use `:Roslyn target` to change the target for the current buffer.",
                         vim.log.levels.INFO,
-                        { title = "roslyn.nvim" })
+                        { title = "roslyn.nvim" }
+                    )
                 end
 
                 if solution then

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -27,7 +27,7 @@ function M.setup(config)
 
     vim.api.nvim_create_autocmd({ "FileType" }, {
         group = vim.api.nvim_create_augroup("Roslyn", { clear = true }),
-        pattern = {"cs", "roslyn-source-generated://*"},
+        pattern = { "cs", "roslyn-source-generated://*" },
         callback = function(opt)
             if not valid_buffer(opt.buf) then
                 return
@@ -43,7 +43,7 @@ function M.setup(config)
                 local root = utils.root(opt.buf)
                 vim.b.roslyn_root = root
 
-                local solution = utils.predict_sln_file(root)
+                local solution = utils.predict_target(root)
                 if solution then
                     vim.g.roslyn_nvim_selected_solution = solution
                     return roslyn_lsp.start(opt.buf, vim.fs.dirname(solution), roslyn_lsp.on_init_sln)

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -43,7 +43,29 @@ function M.setup(config)
                 local root = utils.root(opt.buf)
                 vim.b.roslyn_root = root
 
-                local solution = utils.predict_target(root)
+                local multiple, solution = utils.predict_target(root)
+
+                if multiple then
+                    -- If the user has `lock_target = true` then wait for them
+                    -- to choose a target explicitly before starting the LSP.
+                    --
+                    -- For `lock_target = false`, being asked to choose a target
+                    -- on every opened file would be annoying, so fall back to
+                    -- default handling.
+                    if roslyn_config.lock_target then
+                        vim.notify(
+                            "Multiple potential target files found. Use `:Roslyn target` to select a target.",
+                            vim.log.levels.INFO,
+                            { title = "roslyn.nvim" })
+                        return
+                    end
+
+                    vim.notify(
+                        "Multiple potential target files found. Use `:Roslyn target` to change the target for the current buffer.",
+                        vim.log.levels.INFO,
+                        { title = "roslyn.nvim" })
+                end
+
                 if solution then
                     vim.g.roslyn_nvim_selected_solution = solution
                     return roslyn_lsp.start(opt.buf, vim.fs.dirname(solution), roslyn_lsp.on_init_sln)

--- a/lua/roslyn/sln/api.lua
+++ b/lua/roslyn/sln/api.lua
@@ -3,19 +3,16 @@ local M = {}
 local sysname = vim.uv.os_uname().sysname:lower()
 local iswin = not not (sysname:find("windows") or sysname:find("mingw"))
 
----@param solution string Path to solution
----@return string[] Table of projects in given solution
-function M.projects(solution)
-    local file = io.open(solution, "r")
-    if not file then
-        return {}
-    end
-
+---@param file file* The file handle to the solution file
+---@param solution string The path to the solution file
+---@param match function A function that takes a line from the file, and returns a project path if the line contains a reference to a project file.
+---@return string[] paths Paths to the projects in the solution
+local function projects_core(file, solution, match)
     local paths = {}
 
     for line in file:lines() do
-        local id, name, path = line:match('Project%("{(.-)}"%).*= "(.-)", "(.-)", "{.-}"')
-        if id and name and path and path:match("%.csproj$") then
+        local path = match(line)
+        if path then
             local normalized_path = iswin and path or path:gsub("\\", "/")
             local dirname = vim.fs.dirname(solution)
             local fullpath = vim.fs.joinpath(dirname, normalized_path)
@@ -24,17 +21,66 @@ function M.projects(solution)
         end
     end
 
+    return paths
+end
+
+--- Attempts to extract the project path from a line in a solution file
+---@param line string
+---@return string? path The path to the project file
+local function sln_match(line)
+    local id, name, path = line:match('Project%("{(.-)}"%).*= "(.-)", "(.-)", "{.-}"')
+    if id and name and path and path:match("%.csproj$") then
+        return path
+    end
+end
+
+--- Attempts to extract the project path from a line in a solution filter file
+---@param line string
+---@return string? path The path to the project file
+local function slnf_match(line)
+    return line:match('"(.*%.csproj)"')
+end
+
+---@param target string Path to solution or solution filter file
+---@return string[] Table of projects in given solution
+function M.projects(target)
+    local file = io.open(target, "r")
+    if not file then
+        return {}
+    end
+
+    local paths = target:match("%.sln$") and projects_core(file, target, sln_match)
+        or target:match("%.slnf$") and projects_core(file, target, slnf_match)
+
     file:close()
 
     return paths
 end
 
 ---Checks if a project is part of a solution or not
+---@deprecated Renamed to `exists_in_target`.
 ---@param solution string
 ---@param project string Full path to the csproj file
 ---@return boolean
 function M.exists_in_solution(solution, project)
+    vim.notify(
+        "`exists_in_solution` has been renamed `exists_in_target` and may be removed in a future release",
+        vim.log.levels.WARN,
+        { title = "roslyn.nvim" })
+
     local projects = M.projects(solution)
+
+    return vim.iter(projects):find(function(it)
+        return it == project
+    end) ~= nil
+end
+
+---Checks if a project is part of a solution/solution filter or not
+---@param target string Path to the solution or solution filter
+---@param project string Full path to the project's csproj file
+---@return boolean
+function M.exists_in_target(target, project)
+    local projects = M.projects(target)
 
     return vim.iter(projects):find(function(it)
         return it == project

--- a/lua/roslyn/sln/api.lua
+++ b/lua/roslyn/sln/api.lua
@@ -66,7 +66,8 @@ function M.exists_in_solution(solution, project)
     vim.notify(
         "`exists_in_solution` has been renamed `exists_in_target` and may be removed in a future release",
         vim.log.levels.WARN,
-        { title = "roslyn.nvim" })
+        { title = "roslyn.nvim" }
+    )
 
     local projects = M.projects(solution)
 

--- a/lua/roslyn/sln/utils.lua
+++ b/lua/roslyn/sln/utils.lua
@@ -21,15 +21,14 @@ end
 
 --- @param dir string
 local function ignore_dir(dir)
-    return dir:match("[Bb]in$")
-        or dir:match("[Oo]bj$")
+    return dir:match("[Bb]in$") or dir:match("[Oo]bj$")
 end
 
 --- @param path string
 --- @return string[] slns, string[] slnfs
 local function find_solutions(path)
     local dirs = { path }
-    local slns = {}  --- @type string[]
+    local slns = {} --- @type string[]
     local slnfs = {} --- @type string[]
 
     while #dirs > 0 do
@@ -44,7 +43,7 @@ local function find_solutions(path)
                 elseif name:match("%.slnf$") then
                     slnfs[#slnfs + 1] = vim.fs.normalize(name)
                 end
-            elseif fs_obj_type == 'directory' and not ignore_dir(name) then
+            elseif fs_obj_type == "directory" and not ignore_dir(name) then
                 dirs[#dirs + 1] = name
             end
         end
@@ -112,7 +111,6 @@ function M.root(buffer)
             projects = projects,
         }
     end
-
 
     if broad_search then
         local git_root = vim.fs.root(buffer, ".git")

--- a/lua/roslyn/sln/utils.lua
+++ b/lua/roslyn/sln/utils.lua
@@ -138,12 +138,11 @@ end
 
 ---Tries to predict which target to use if we found some
 ---returning the potentially predicted target
----Notifies the user if we still have multiple to choose from
 ---@param root RoslynNvimRootDir
----@return string?
+---@return boolean multiple, string? predicted_target
 function M.predict_target(root)
     if not root.solutions then
-        return nil
+        return false, nil
     end
 
     local config = require("roslyn.config").get()
@@ -167,17 +166,12 @@ function M.predict_target(root)
         local chosen = config.choose_target and config.choose_target(filtered_targets)
 
         if chosen then
-            return chosen
+            return false, chosen
         end
 
-        vim.notify(
-            "Multiple target files found. Use `:Roslyn target` to select or change target for buffer",
-            vim.log.levels.INFO,
-            { title = title }
-        )
-        return nil
+        return true, nil
     else
-        return filtered_targets[1]
+        return false, filtered_targets[1]
     end
 end
 


### PR DESCRIPTION
Closes #125

The options in the select targets list now look much the same as "Open Solution" in VSCode. Could be cool to do a proximity sort or something in the future...

I've left out flowing solution filters through to `predict_sln_file` to avoid behaviour changes, which means they can only be selected manually for now. In a future release it'd be handy to flow them through to `choose_target`, if and when you decide to rename the options, as discussed in the issue. I'll probably do so in my fork in the meantime, so feel free to ping me for a PR if wanted.