### PR TITLE
feat: add slnx support

### DIFF
--- a/lua/roslyn/commands.lua
+++ b/lua/roslyn/commands.lua
@@ -58,7 +58,7 @@ local subcommand_tbl = {
     target = {
         impl = function()
             local bufnr = vim.api.nvim_get_current_buf()
-            local root = vim.b.roslyn_root or require("roslyn.utils").root(bufnr)
+            local root = vim.b.roslyn_root or require("roslyn.sln.utils").root(bufnr)
 
             local roslyn_lsp = require("roslyn.lsp")
 

--- a/lua/roslyn/sln/utils.lua
+++ b/lua/roslyn/sln/utils.lua
@@ -38,7 +38,7 @@ local function find_solutions(path)
             local name = vim.fs.joinpath(dir, other)
 
             if fs_obj_type == "file" then
-                if name:match("%.sln$") then
+                if name:match("%.sln$") or name:match("%.slnx$") then
                     slns[#slns + 1] = vim.fs.normalize(name)
                 elseif name:match("%.slnf$") then
                     slnfs[#slnfs + 1] = vim.fs.normalize(name)
@@ -75,7 +75,7 @@ local function find_targets(buffer)
             slnf_dir = path
         end
 
-        return name:match("%.sln$") ~= nil
+        return name:match("%.sln$") ~= nil or name:match("%.slnx$")
     end)
 
     return { csproj_dir = csproj_dir, sln_dir = sln_dir, slnf_dir = slnf_dir }
@@ -125,9 +125,11 @@ function M.root(buffer)
         }
     else
         local slnf = targets.slnf_dir
+        local slns = find_files_with_extension(sln, ".sln")
+        local slnxs = find_files_with_extension(sln, ".slnx")
 
         return {
-            solutions = find_files_with_extension(sln, ".sln"),
+            solutions = vim.list_extend(slns, slnxs),
             solution_filters = slnf and find_files_with_extension(slnf, ".slnf"),
             projects = projects,
         }


### PR DESCRIPTION
## Description
Adds support for the new slnx file format. Treats slnx and sln as interchangeable. I think this makes sense as the purpose of the file is the same, and the contents should also represent the same

Implemented the same for easy-dotnet.nvim
- gustaveikaas/easy-dotnet.nvim#220


Also fixed a bug with the `Roslyn target` command. `require("roslyn.utils")` -> `require("roslyn.sln.utils")`