### PR TITLE
fix!: remove hacky pipe start and prefer stdio

### DIFF
--- a/lua/roslyn/config.lua
+++ b/lua/roslyn/config.lua
@@ -130,6 +130,15 @@ function M.setup(user_config)
         end
     end
 
+    if not vim.tbl_contains(roslyn_config.args, "--stdio") then
+        vim.notify(
+            "roslyn.nvim requires the `--stdio` argument to be present. Please add it to your configuration",
+            vim.log.levels.WARN,
+            { title = "roslyn.nvim" }
+        )
+        table.insert(roslyn_config.args, "--stdio")
+    end
+
     -- HACK: Enable filewatching to later just not watch any files
     -- This is to not make the server watch files and make everything super slow in certain situations
     if not roslyn_config.filewatching then

--- a/lua/roslyn/lsp.lua
+++ b/lua/roslyn/lsp.lua
@@ -24,13 +24,15 @@ function M.start(bufnr, root_dir, on_init)
         ["workspace/projectInitializationComplete"] = function(_, _, ctx)
             vim.notify("Roslyn project initialization complete", vim.log.levels.INFO, { title = "roslyn.nvim" })
 
+            ---NOTE: This is used by rzls.nvim for init
+            vim.api.nvim_exec_autocmds("User", { pattern = "RoslynInitialized", modeline = false })
+            _G.roslyn_initialized = true
+
             local buffers = vim.lsp.get_buffers_by_client_id(ctx.client_id)
             for _, buf in ipairs(buffers) do
                 vim.lsp.util._refresh("textDocument/diagnostic", { bufnr = buf })
             end
 
-            ---NOTE: This is used by rzls.nvim for init
-            vim.api.nvim_exec_autocmds("User", { pattern = "RoslynInitialized", modeline = false })
         end,
         ["workspace/_roslyn_projectHasUnresolvedDependencies"] = function()
             vim.notify("Detected missing dependencies. Run dotnet restore command.", vim.log.levels.ERROR, {


### PR DESCRIPTION
- Added a check for the `--stdio` argument in `config.lua` to ensure it is
  present in the configuration. If not, it will be added and a warning
  notification will be shown.
- Moved the `RoslynInitialized` autocmd execution in `lsp.lua` to ensure it
  runs before refreshing diagnostics.
- Added global variable for checking if roslyn is initialized