### PR TITLE
Fix: Roslyn binary not found in oil.nvim

### DIFF
--- a/lsp/roslyn.lua
+++ b/lsp/roslyn.lua
@@ -4,16 +4,12 @@ local iswin = not not (sysname:find("windows") or sysname:find("mingw"))
 -- Default to roslyn presumably installed by mason if found.
 -- Fallback to the same default as `nvim-lspconfig`
 local function get_default_cmd()
-    local roslyn = iswin and "roslyn.cmd" or "roslyn"
-    local mason_bin = vim.fn.stdpath("data") .. "/mason/bin/" .. roslyn
+    local roslyn_bin = iswin and "roslyn.cmd" or "roslyn"
+    local mason_bin = vim.fs.joinpath(vim.fn.stdpath("data"), "mason", "bin", roslyn_bin)
 
-    local exe = nil
-
-    if vim.fn.executable(mason_bin) == 1 then
-        exe = mason_bin
-    else
-        exe = vim.fn.executable(roslyn) == 1 and roslyn or "Microsoft.CodeAnalysis.LanguageServer"
-    end
+    local exe = vim.fn.executable(mason_bin) == 1 and mason_bin
+        or vim.fn.executable(roslyn_bin) == 1 and roslyn_bin
+        or "Microsoft.CodeAnalysis.LanguageServer"
 
     return {
         exe,


### PR DESCRIPTION
This change preferentially looks for and selects the binary installed by mason, since plugins like oil.nvim won't find it if you start nvim with nvim.

It also avoids the error if you do not have any file manager :)
Screenshots:

<img width="1904" height="1030" alt="image" src="https://github.com/user-attachments/assets/7813c37a-89c1-4691-8426-01f57a0bb4c8" />

