### PR TITLE
feat(diagnostics): add explicit refresh on save and insert leave

### DIFF
--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -20,6 +20,18 @@ function M.setup(config)
         end,
     })
 
+    local diagnostic = require("roslyn.lsp.diagnostics")
+    vim.api.nvim_create_autocmd({ "BufWritePost", "InsertLeave" }, {
+        group = group,
+        pattern = "*.cs",
+        callback = function()
+            local client = vim.lsp.get_clients({ name = "roslyn" })[1]
+            if client then
+                diagnostic.refresh(client)
+            end
+        end,
+    })
+
     vim.treesitter.language.register("c_sharp", "csharp")
 
     vim.api.nvim_create_autocmd({ "BufReadCmd" }, {

--- a/lua/roslyn/lsp/diagnostics.lua
+++ b/lua/roslyn/lsp/diagnostics.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+---@param client vim.lsp.Client
+function M.refresh(client)
+    local buffers = vim.lsp.get_buffers_by_client_id(client.id)
+    for _, buf in ipairs(buffers) do
+        if vim.api.nvim_buf_is_loaded(buf) then
+            client:request(
+                vim.lsp.protocol.Methods.textDocument_diagnostic,
+                { textDocument = vim.lsp.util.make_text_document_params(buf) },
+                nil,
+                buf
+            )
+        end
+    end
+end
+
+return M

--- a/lua/roslyn/lsp/handlers.lua
+++ b/lua/roslyn/lsp/handlers.lua
@@ -1,3 +1,5 @@
+local diagnostics = require("roslyn.lsp.diagnostics")
+
 return {
     ["client/registerCapability"] = function(err, res, ctx)
         if require("roslyn.config").get().filewatching == "off" then
@@ -23,11 +25,9 @@ return {
         _G.roslyn_initialized = true
 
         local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
-        local buffers = vim.lsp.get_buffers_by_client_id(ctx.client_id)
-        for _, buf in ipairs(buffers) do
-            local params = { textDocument = vim.lsp.util.make_text_document_params(buf) }
-            client:request("textDocument/diagnostic", params, nil, buf)
-        end
+
+        -- Add diagnostics when project init
+        diagnostics.refresh(client)
     end,
     ["workspace/refreshSourceGeneratedDocument"] = function(_, _, ctx)
         local client = assert(vim.lsp.get_client_by_id(ctx.client_id))


### PR DESCRIPTION
Problem:
Roslyn LSP diagnostics in Neovim are not always updated immediately after editing. This can lead to stale or missing diagnostics until other actions (such as cursor movement or manual refresh) trigger a diagnostic request.

Solution:
Introduce a `diagnostics.refresh(client)` helper that explicitly requests `textDocument/diagnostic` from the server for all buffers attached to the client. This is hooked into `BufWritePost` and `InsertLeave` for C# files.

Rationale:
Refreshing diagnostics after saving or leaving insert mode ensures that the developer sees up-to-date errors and warnings without waiting for implicit LSP events. The implementation follows the plugin’s existing style by indexing `vim.lsp.get_clients()[1]` for consistency, and includes safe checks to prevent errors when the Roslyn client is not attached.