### PR TITLE
fix: load plugin/roslyn.lua only once

### DIFF
--- a/plugin/roslyn.lua
+++ b/plugin/roslyn.lua
@@ -1,3 +1,8 @@
+if vim.g.loaded_roslyn_plugin ~= nil then
+    return
+end
+vim.g.loaded_roslyn_plugin = true
+
 if vim.fn.has("nvim-0.11") == 0 then
     return vim.notify("roslyn.nvim requires at least nvim 0.11", vim.log.levels.WARN, { title = "roslyn.nvim" })
 end


### PR DESCRIPTION
Lua files in plugin/ can be sourced (`:runtime …`) multiple times and are expected to handle this themselves, usually by setting a `g:loaded_…` variable.

The current version of plugin/roslyn.lua is probably idempotent and doesn't necessarily need a guard to prevent repeated executions, but there's one scenario where such guard is useful:

For security reasons, I don't want to enable LSPs in untrusted projects, so I don't vim.lsp.enable by default and instead only do it per-project. Therefore I need to `vim.lsp.enable('roslyn', false)` after plugin/roslyn.lua, and then `vim.lsp.enable('roslyn')` for specific projects that are trusted. The per-project vimrc plugin, however, happens to be run before plugin/roslyn.lua, so this is difficult to do without ugly workarounds. If I could `:runtime plugin/roslyn.lua` early and `vim.lsp.enable('roslyn', false)` immediately after, this becomes much easier.

Fixes: https://github.com/seblyng/roslyn.nvim/commit/1a4a5fbc74447b0926ded14979d381d3d7e74cb8#r165346141
