### PR TITLE
fix: exec autocmd when initialized

### DIFF
--- a/lua/roslyn/lsp/handlers.lua
+++ b/lua/roslyn/lsp/handlers.lua
@@ -61,6 +61,7 @@ return {
             end
         end
     end,
+    -- TODO: This is no longer needed with latest roslyn: https://github.com/dotnet/roslyn/pull/81233
     ["workspace/_roslyn_projectNeedsRestore"] = function(_, result, ctx)
         local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
 


### PR DESCRIPTION
I see that I actually also myself depended on this in my config, so I think we should add it back😅

I am using `silent = true` option to turn off the init notification from vim.notify, and implement the notification with fidget