### PR TITLE
feat(target): Use relative paths when selecting solution file

### DIFF
--- a/lua/roslyn/commands.lua
+++ b/lua/roslyn/commands.lua
@@ -58,11 +58,6 @@ local subcommand_tbl = {
             local utils = require("roslyn.sln.utils")
             local broad_search = require("roslyn.config").get().broad_search
             local targets = broad_search and utils.find_solutions_broad(bufnr) or utils.find_solutions(bufnr)
-            -- local relative_targets = {}
-            -- for key, value in pairs(targets) do
-            --     local target_relative_from_cwd = vim.fn.fnamemodify(value, ":.")
-            --     relative_targets[key] = target_relative_from_cwd
-            -- end
             vim.ui.select(targets or {}, {
                 prompt = "Select target solution: ",
                 format_item = function(item)


### PR DESCRIPTION
## Problem

When using `:lua Roslyn target` to select a solution file on smaller screens, the absolute paths were too long and caused the solution name (the most important part) to be cut off in the selection UI. This made it difficult to identify which solution to choose.

<details>
  <summary>Example of solution being cut off</summary>
  <img width="900px" height="520" alt="image" src="https://github.com/user-attachments/assets/1cdd89b4-a7cb-4cce-b73f-18f7568e19e0" />
</details>


## Solution

Modified the solution selection UI to display relative paths instead of absolute paths. The paths are now relative to the cwd, making them shorter and ensuring the solution names remain visible on smaller screens.

<details>
  <summary>Example of solution selection with relative path</summary>
  <img width="900px" height="464" alt="image" src="https://github.com/user-attachments/assets/66435e35-0c3d-440d-ba2d-a3cabd84776a" />
</details>