### PR TITLE
fix: LSP navigation in decompiled files

### DIFF
--- a/lsp/roslyn.lua
+++ b/lsp/roslyn.lua
@@ -61,6 +61,8 @@ return {
     cmd = get_default_cmd(),
     cmd_env = {
         Configuration = vim.env.Configuration or "Debug",
+        -- Fixes LSP navigation in decompiled files for systems with symlinked TMPDIR (macOS)
+        TMPDIR = vim.fn.resolve(vim.env.TMPDIR)
     },
     capabilities = {
         textDocument = {


### PR DESCRIPTION
Fixes LSP navigation inside decompiled files for systems with symlinked `TMPDIR` (issue #116)

The roslyn LS relies on the standard `TMPDIR` environment variable to figure out where to put decompiled files.
On macOS, `TMPDIR` points to `/var` (= symlink to `/private/var`) and navigating to external symbols currently triggers this chain of event:

**Navigation from local file to decompiled file**
- The neovim LSP client issues a `textDocument/*` request to the language server, providing the relevant text range + **symlink-resolved** file path (ex: `~/repos/project/file.cs`).
- The language server processes the request: it generates and caches the decompiled source file under directory `$TMPDIR`, then returns its path to the client **without symlinks resolved** (`/var/**/decompiled1.cs`)
- Neovim then navigates to the received file (`/var/**/decompiled1.cs`)

**Navigation from decompiled file to other decompiled file**
- The neovim LSP client issues another `textDocument/*` request, with **symlink-resolved** file path (`/var/**/decompiled1.cs` then becomes `/private/var/**/decompiled1.cs`)
- The language server does not recognize this path => navigation from inside decompiled files does not work

```
[DEBUG][2026-01-25 13:59:11] .../vim/lsp/rpc.lua:277	"rpc.send"	{ id = 11, jsonrpc = "2.0", method = "textDocument/definition", params = { position = { character = 106, line = 26 }, textDocument = { uri = "file:///private/var/folders/_r/f4ptb77s2595z3hpdsb4xldw0000gn/T/MetadataAsSource/6593bce3b8bc47e0bef45a7d071ba03d/DecompilationMetadataAsSourceFileProvider/c7ef4064993141db8a569592a1a70fd2/ServiceCollectionExtensions.cs" } } }
[DEBUG][2026-01-25 13:59:11] .../vim/lsp/rpc.lua:391	"rpc.receive"	{ id = 11, jsonrpc = "2.0", result = {} }
```

It seems roslyn LS could be maintaining in-memory state about which paths it decompiled to, and this logic doesn't handle symlinks? Overriding roslyn LS's `TMPDIR` to remove symlinks allows to work around this, then client and server both communicate decompiled file paths with symlinks resolved and this fixes the issue.