### PR TITLE
fix: skip LSP attachment for virtual buffers with URI schemes

### DIFF
--- a/lsp/roslyn.lua
+++ b/lsp/roslyn.lua
@@ -96,6 +96,13 @@ return {
             end
         end
 
+        -- Don't attach to virtual buffers with URI schemes (diffview://, fugitive://, etc.)
+        -- By not calling on_dir(), we prevent LSP attachment entirely for these buffers
+        -- See: https://github.com/neovim/neovim/issues/33061
+        if buf_name:match("^%w+://") then
+            return
+        end
+
         local root_dir = require("roslyn.sln.utils").root_dir(bufnr)
         on_dir(root_dir)
     end,


### PR DESCRIPTION
Opening a diff in DiffView or Fugitive for a .cs file creates duplicate Roslyn LSP clients. These plugins open the git version in a virtual buffer with a URI scheme (e.g., diffview://..., fugitive://...), and both buffers trigger the root_dir callback simultaneously, creating two clients.

This fix skips LSP attachment entirely for virtual buffers by not calling on_dir() when the buffer name uses a URI scheme.