### PR TITLE
fix: explicitly start roslyn server for source generated files

### DIFF
--- a/lua/roslyn/lsp/handlers.lua
+++ b/lua/roslyn/lsp/handlers.lua
@@ -47,6 +47,7 @@ return {
                     vim.api.nvim_buf_set_lines(buf, 0, -1, false, source_lines)
                     vim.b[buf].resultId = result.resultId
                     vim.bo[buf].modifiable = false
+                    vim.bo[buf].modified = false
                 end
 
                 local params = {

--- a/plugin/roslyn.lua
+++ b/plugin/roslyn.lua
@@ -62,6 +62,15 @@ vim.api.nvim_create_autocmd({ "BufReadCmd" }, {
         -- This triggers FileType event which should fire up the lsp client if not already running
         vim.bo[args.buf].filetype = "cs"
         local client = vim.lsp.get_clients({ name = "roslyn", bufnr = args.buf })[1]
+            or vim.lsp.get_clients({ name = "roslyn" })[1]
+        if not client then
+            vim.wait(5000, function()
+                return next(vim.lsp.get_clients({ name = "roslyn", bufnr = args.buf })) ~= nil
+            end)
+            client = vim.lsp.get_clients({ name = "roslyn", bufnr = args.buf })[1]
+        else
+            vim.lsp.buf_attach_client(args.buf, client.id)
+        end
         assert(client, "Must have a `roslyn` client to load roslyn source generated file")
 
         local content
@@ -76,6 +85,7 @@ vim.api.nvim_create_autocmd({ "BufReadCmd" }, {
             vim.api.nvim_buf_set_lines(args.buf, 0, -1, false, source_lines)
             vim.b[args.buf].resultId = result.resultId
             vim.bo[args.buf].modifiable = false
+            vim.bo[args.buf].modified = false
         end
 
         local params = {


### PR DESCRIPTION
Do a hacky timout wait for source generarated files similar to how it is done in https://github.com/mfussenegger/nvim-jdtls for decompiled files.

Feels like it should be possible to use vim.lsp.start to do this less hacky, but I just got weird bugs, and I am tired of this


Fixes #305 