### PR TITLE
feat: show init timer, solution name, and deduplicate notifications

### DIFF
--- a/lua/roslyn/lsp/on_init.lua
+++ b/lua/roslyn/lsp/on_init.lua
@@ -1,10 +1,13 @@
 local M = {}
 
 function M.sln(client, solution)
-    require("roslyn.store").set(client.id, solution)
+    local store = require("roslyn.store")
+    store.set(client.id, solution)
+    store.set_init_start(client.id)
 
     if not require("roslyn.config").get().silent then
-        vim.notify("Initializing Roslyn for: " .. solution, vim.log.levels.INFO, { title = "roslyn.nvim" })
+        local sln_name = vim.fn.fnamemodify(solution, ":t:r")
+        vim.notify("Initializing\n" .. sln_name, vim.log.levels.INFO, { title = "roslyn.nvim" })
     end
 
     client:notify("solution/open", {
@@ -22,8 +25,10 @@ function M.sln(client, solution)
 end
 
 function M.project(client, projects)
+    require("roslyn.store").set_init_start(client.id)
+
     if not require("roslyn.config").get().silent then
-        vim.notify("Initializing Roslyn for: project", vim.log.levels.INFO, { title = "roslyn.nvim" })
+        vim.notify("Initializing project", vim.log.levels.INFO, { title = "roslyn.nvim" })
     end
     client:notify("project/open", {
         projects = vim.tbl_map(function(file)

--- a/lua/roslyn/store.lua
+++ b/lua/roslyn/store.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local client_id_to_solution = {}
+local client_id_to_start_time = {}
 
 ---@param client_id integer
 ---@param solution? string
@@ -12,6 +13,20 @@ end
 ---@param client_id integer
 function M.get(client_id)
     return client_id_to_solution[client_id]
+end
+
+---@param client_id integer
+function M.set_init_start(client_id)
+    client_id_to_start_time[client_id] = vim.uv.now()
+end
+
+---@param client_id integer
+---@return integer? milliseconds since init start, or nil if not recorded
+function M.get_init_elapsed_ms(client_id)
+    local start = client_id_to_start_time[client_id]
+    if start then
+        return vim.uv.now() - start
+    end
 end
 
 return M


### PR DESCRIPTION
## Summary

### Problem
- The `workspace/projectInitializationComplete` notification can fire more than once from the Roslyn server (observed with Unity solutions that have multiple projects). This results in duplicate "Roslyn project initialization complete" popups.
- The initialization notification showed the full solution path, which is verbose and redundant since the title already says "roslyn.nvim".

### Changes

**Deduplicate notifications** (`handlers.lua`)
Added a per-session `initialized_clients` table keyed by `client_id`. The notification fires only on the first `projectInitializationComplete` event per client. `diagnostics.refresh()` and the `RoslynInitialized` autocmd still run on every event (they are idempotent).

**Initialization timer** (`store.lua`, `on_init.lua`, `handlers.lua`)
Records `vim.uv.now()` (monotonic ms) when `solution/open` is sent, then calculates elapsed time on completion. The completion notification now shows two lines:
```
Panda_Unity6_2
initialization complete in 14.3 sec
```

**Cleaner "Initializing" notification** (`on_init.lua`)
Changed from `"Initializing Roslyn for: /full/path/to/Solution.sln"` to a two-line format:
```
Initializing
SolutionName
```
using `vim.fn.fnamemodify(solution, ":t:r")` to extract just the name.

## Test plan

- [ ] Open a C# project — verify single "Initializing / SolutionName" notification appears
- [ ] Wait for initialization — verify single "SolutionName / initialization complete in X.X sec" notification appears
- [ ] Verify no duplicate notifications appear even when server sends `projectInitializationComplete` multiple times
- [ ] Run `:Roslyn restart` — verify notifications appear again for the new client

🤖 Generated with [Claude Code](https://claude.com/claude-code)