### PR TITLE
fix: replace deprecated vim.loop with vim.uv and fix version check

### DIFF
--- a/lua/roslyn/commands.lua
+++ b/lua/roslyn/commands.lua
@@ -38,7 +38,7 @@ local subcommand_tbl = {
                 vim.lsp.enable("roslyn")
             end)
 
-            local force_stop = vim.loop.os_uname().sysname == "Windows_NT"
+            local force_stop = vim.uv.os_uname().sysname == "Windows_NT"
             client:stop(force_stop)
         end,
     },
@@ -50,7 +50,7 @@ local subcommand_tbl = {
                 return
             end
 
-            local force_stop = vim.loop.os_uname().sysname == "Windows_NT"
+            local force_stop = vim.uv.os_uname().sysname == "Windows_NT"
             client:stop(force_stop)
         end,
     },
@@ -91,7 +91,7 @@ local subcommand_tbl = {
                     vim.lsp.start(config, { bufnr = bufnr })
                 end)
 
-                local force_stop = vim.loop.os_uname().sysname == "Windows_NT"
+                local force_stop = vim.uv.os_uname().sysname == "Windows_NT"
                 client:stop(force_stop)
             end)
         end,

--- a/lua/roslyn/health.lua
+++ b/lua/roslyn/health.lua
@@ -38,7 +38,7 @@ function M.check()
     vim.health.start("roslyn.nvim: Requirements")
 
     local v = vim.version()
-    if v.major == 0 and v.minor >= 11 then
+    if v.major > 0 or (v.major == 0 and v.minor >= 11) then
         vim.health.ok("Neovim >= 0.11")
     else
         vim.health.error(


### PR DESCRIPTION
## Summary

Two small correctness fixes:

**Replace `vim.loop` with `vim.uv`** (`commands.lua`)

`vim.loop` was deprecated in Neovim 0.10 in favour of `vim.uv`. There were 3 occurrences in `commands.lua` for the Windows detection check. `health.lua` already used `vim.uv` correctly — this makes the codebase consistent.

**Fix Neovim version check** (`health.lua`)

```lua
-- before
if v.major == 0 and v.minor >= 11 then

-- after
if v.major > 0 or (v.major == 0 and v.minor >= 11) then
```

The original condition would incorrectly report a health error once Neovim 1.0 is released, since `v.major` would be `1` and `v.minor` would reset to `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)