### PR TITLE
fix: guard against nil in root_dir when all targets are filtered out

### DIFF
--- a/lua/roslyn/sln/utils.lua
+++ b/lua/roslyn/sln/utils.lua
@@ -167,7 +167,7 @@ function M.root_dir(bufnr)
     end
 
     local selected_solution = vim.g.roslyn_nvim_selected_solution
-    return vim.fs.dirname(filtered_targets[1])
+    return filtered_targets[1] and vim.fs.dirname(filtered_targets[1])
         or selected_solution and vim.fs.dirname(selected_solution)
         or csproj and vim.fs.dirname(csproj)
 end


### PR DESCRIPTION
## Summary

In `sln/utils.lua`, `root_dir` calls `filter_targets` and then falls through to:

```lua
return vim.fs.dirname(filtered_targets[1])
    or selected_solution and vim.fs.dirname(selected_solution)
    or csproj and vim.fs.dirname(csproj)
```

If `ignore_target` rejects every found solution, `filtered_targets` is empty and `filtered_targets[1]` is `nil`. Passing `nil` to `vim.fs.dirname` raises a bad-argument error, crashing LSP startup.

**Fix:** add a nil guard so the fallback chain works correctly:

```lua
return filtered_targets[1] and vim.fs.dirname(filtered_targets[1])
    or selected_solution and vim.fs.dirname(selected_solution)
    or csproj and vim.fs.dirname(csproj)
```

## Reproducer

```lua
-- roslyn.nvim config
ignore_target = function(_) return true end  -- reject all solutions
```

Open a `.cs` file — without this fix, LSP startup crashes silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)