### PR TITLE
perf: keep log file handle open instead of open/close on every write

### DIFF
--- a/lua/roslyn/log.lua
+++ b/lua/roslyn/log.lua
@@ -1,19 +1,23 @@
 local M = {}
 
+local log_file = vim.fs.joinpath(vim.fn.stdpath("state"), "roslyn.log")
+local file_handle = nil
+
 ---@param msg string
 function M.log(msg)
     if not require("roslyn.config").get().debug then
         return
     end
 
-    local log_file = vim.fs.joinpath(vim.fn.stdpath("state"), "roslyn.log")
-    vim.fn.mkdir(vim.fs.dirname(log_file), "p")
+    if not file_handle then
+        vim.fn.mkdir(vim.fs.dirname(log_file), "p")
+        file_handle = io.open(log_file, "a")
+    end
 
-    local f = io.open(log_file, "a")
-    if f then
+    if file_handle then
         local ts = os.date("%Y-%m-%d %H:%M:%S")
-        f:write(string.format("[%s] %s\n", ts, msg))
-        f:close()
+        file_handle:write(string.format("[%s] %s\n", ts, msg))
+        file_handle:flush()
     end
 end
 


### PR DESCRIPTION
## Summary

With `debug = true`, `M.log` is called frequently from hot paths like `find_solutions` and `predict_target`. Each call did:

```lua
local f = io.open(log_file, "a")   -- open
f:write(...)                        -- write
f:close()                           -- close
```

Three syscalls per log entry. On a large Unity project with hundreds of directory entries this adds up.

**Fix:** open the handle lazily on the first call and keep it open for the session, using `flush()` to ensure writes are visible immediately:

```lua
local file_handle = nil

function M.log(msg)
    if not file_handle then
        vim.fn.mkdir(...)
        file_handle = io.open(log_file, "a")
    end
    if file_handle then
        file_handle:write(...)
        file_handle:flush()
    end
end
```

`mkdir` is also moved inside the lazy-init block so it only runs once instead of on every log call.

The handle is intentionally never explicitly closed — Lua's GC will close it when the module is collected (i.e. when Neovim exits), which is the correct lifetime for a session-scoped log file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)