### PR TITLE
refactor: simplify exists_in_target using vim.list_contains

### DIFF
--- a/lua/roslyn/sln/api.lua
+++ b/lua/roslyn/sln/api.lua
@@ -58,11 +58,7 @@ end
 ---@param project string Full path to the project's csproj file
 ---@return boolean
 function M.exists_in_target(target, project)
-    local projects = M.projects(target)
-
-    return vim.iter(projects):find(function(it)
-        return it == project
-    end) ~= nil
+    return vim.list_contains(M.projects(target), project)
 end
 
 return M


### PR DESCRIPTION
## Summary

`exists_in_target` used `vim.iter():find()` with an equality callback just to check membership:

```lua
return vim.iter(projects):find(function(it)
    return it == project
end) ~= nil
```

`vim.list_contains` does exactly this — linear scan for equality — in one call:

```lua
return vim.list_contains(M.projects(target), project)
```

No behaviour change, just less noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)