### PR TITLE
fix: potential incorrect config when LSP client started

### DIFF
--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -3,6 +3,7 @@ local M = {}
 ---@param config? RoslynNvimConfig
 function M.setup(config)
     require("roslyn.config").setup(config)
+    vim.lsp.enable("roslyn")
 end
 
 return M

--- a/plugin/roslyn.lua
+++ b/plugin/roslyn.lua
@@ -7,8 +7,6 @@ if vim.fn.has("nvim-0.11") == 0 then
     return vim.notify("roslyn.nvim requires at least nvim 0.11", vim.log.levels.WARN, { title = "roslyn.nvim" })
 end
 
-vim.lsp.enable("roslyn")
-
 vim.treesitter.language.register("c_sharp", "csharp")
 
 vim.filetype.add({


### PR DESCRIPTION
This pull request makes a minor change to how the Roslyn LSP is enabled in the Neovim plugin. The call to enable the Roslyn LSP has been moved from the plugin initialization file to the module setup function, ensuring that the LSP is only enabled when the user explicitly sets up the plugin.

I found this issue by having unexpected behaviour when I changed some config, I'm not sure if it's because "auto-session", but after hours of debugging, it turns out LSP client could initialize before plugin's setup() been called.

* Moved `vim.lsp.enable("roslyn")` from `plugin/roslyn.lua` to `lua/roslyn/init.lua` within the `M.setup` function, so Roslyn LSP is enabled during plugin setup rather than at plugin load time. [[1]](diffhunk://#diff-57420926d54f41f86c1b50d9552cf164dd66a88f0e38e8f24c659d7aa4fcc9cfR6) [[2]](diffhunk://#diff-000340d472aa347d757dc5b0f10701b085f0d61124519bc731bfa44c072056c5L10-L11)