### PR TITLE
feat: add dim_inactive_region option to grey out codes embraced by in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ opts = {
 
     -- If the plugin should silence notifications about initialization
     silent = false,
+
+    -- Whether or not to dim inactive regions of code inside preprocessor
+    -- directives (#if/#else/#endif) where the condition evaluates to false.
+    -- When enabled, inactive code is displayed with the `DiagnosticUnnecessary`
+    -- highlight (gray by default). You can override the appearance by setting
+    -- the `@lsp.type.excludedCode` or `@lsp.type.excludedCode.cs` highlight group.
+    dim_inactive_regions = true,
 }
 ```
 

--- a/lua/roslyn/config.lua
+++ b/lua/roslyn/config.lua
@@ -8,6 +8,7 @@ local M = {}
 ---@field lock_target boolean
 ---@field silent boolean
 ---@field debug boolean
+---@field dim_inactive_regions boolean
 
 ---@class RoslynNvimConfig
 ---@field filewatching? boolean | "auto" | "off" | "roslyn"
@@ -17,6 +18,7 @@ local M = {}
 ---@field lock_target? boolean
 ---@field silent? boolean
 ---@field debug? boolean
+---@field dim_inactive_regions? boolean
 
 ---@type InternalRoslynNvimConfig
 local roslyn_config = {
@@ -27,6 +29,7 @@ local roslyn_config = {
     lock_target = false,
     silent = false,
     debug = false,
+    dim_inactive_regions = true,
 }
 
 function M.get()

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -2,7 +2,11 @@ local M = {}
 
 ---@param config? RoslynNvimConfig
 function M.setup(config)
-    require("roslyn.config").setup(config)
+    local resolved = require("roslyn.config").setup(config)
+
+    if resolved.dim_inactive_regions then
+        vim.api.nvim_set_hl(0, "@lsp.type.excludedCode", { default = true, link = "DiagnosticUnnecessary" })
+    end
 end
 
 return M


### PR DESCRIPTION
This pull request introduces a new configuration option to control the dimming of inactive code regions inside preprocessor directives. The option is documented, added to the configuration schema, given a default value, and hooked into the plugin initialization to set up the appropriate highlight group.

<img width="558" height="275" alt="图片" src="https://github.com/user-attachments/assets/239133e4-1124-421c-a2d0-d1845301897d" />

**New feature: Dimming inactive code regions**

* Added a `dim_inactive_regions` option to the configuration schema in `lua/roslyn/config.lua`, allowing users to enable or disable dimming of inactive code regions. [[1]](diffhunk://#diff-7412f1cf07b90a7c2d1bf5e5ce2297f1d01668176a41fa051c8996a962bb0cafR11) [[2]](diffhunk://#diff-7412f1cf07b90a7c2d1bf5e5ce2297f1d01668176a41fa051c8996a962bb0cafR21)
* Set the default value of `dim_inactive_regions` to `true` in the internal configuration.
* Updated the documentation in `README.md` to describe the new option and how it affects code highlighting.

**Plugin initialization**

* Modified `lua/roslyn/init.lua` to set the `@lsp.type.excludedCode` highlight group to link to `DiagnosticUnnecessary` when `dim_inactive_regions` is enabled, ensuring inactive code is visually dimmed.