### PR TITLE
fix:prevent-server-stop-on-duplicate-didopen

### DIFF
--- a/lua/roslyn/lsp/on_init.lua
+++ b/lua/roslyn/lsp/on_init.lua
@@ -1,6 +1,39 @@
 local M = {}
 
+--- Setup RPC wrapper to prevent duplicate textDocument/didOpen notifications
+--- This fixes crashes when switching buffers via Telescope/Neotree
+---@param client vim.lsp.Client
+local function setup_didopen_guard(client)
+    -- Skip if already guarded
+    if client._roslyn_didopen_guard then
+        return
+    end
+    client._roslyn_didopen_guard = true
+
+    local opened_uris = {}
+    local orig_notify = client.rpc.notify
+    client.rpc.notify = function(method, params)
+        if method == "textDocument/didOpen" then
+            local uri = params and params.textDocument and params.textDocument.uri
+            if uri then
+                if opened_uris[uri] then
+                    -- Duplicate didOpen detected - block it
+                    return
+                end
+                opened_uris[uri] = true
+            end
+        elseif method == "textDocument/didClose" then
+            local uri = params and params.textDocument and params.textDocument.uri
+            if uri then
+                opened_uris[uri] = nil
+            end
+        end
+        return orig_notify(method, params)
+    end
+end
+
 function M.sln(client, solution)
+    setup_didopen_guard(client)
     require("roslyn.store").set(client.id, solution)
 
     if not require("roslyn.config").get().silent then
@@ -22,6 +55,7 @@ function M.sln(client, solution)
 end
 
 function M.project(client, projects)
+    setup_didopen_guard(client)
     if not require("roslyn.config").get().silent then
         vim.notify("Initializing Roslyn for: project", vim.log.levels.INFO, { title = "roslyn.nvim" })
     end

--- a/test/lsp_integration_spec.lua
+++ b/test/lsp_integration_spec.lua
@@ -650,4 +650,143 @@ describe("LSP integration with mock server", function()
         assert.is_true(vim.tbl_contains(solutions, to_uri(vim.fs.joinpath(scratch, "src", "Bar", "Bar.sln"))))
         assert.is_true(vim.tbl_contains(solutions, to_uri(vim.fs.joinpath(scratch, "src", "Root.sln"))))
     end)
+
+    it("prevents duplicate textDocument/didOpen notifications", function()
+        create_sln_file("Foo.sln", { { name = "Bar", path = "Bar/Bar.csproj" } })
+        create_file("Bar/Bar.csproj")
+        create_file("Bar/Program.cs")
+        create_file("Bar/Other.cs")
+
+        -- Clear any previous RPC notifications
+        helpers.exec_lua(function()
+            require("test.utils.mock_server").reset()
+        end)
+
+        -- Open first file
+        command("edit " .. vim.fs.joinpath(helpers.scratch, "Bar", "Program.cs"))
+        local bufnr1 = helpers.api.nvim_get_current_buf()
+
+        -- Wait for LSP to fully attach and send didOpen
+        helpers.exec_lua(function()
+            vim.wait(100, function() end)
+        end)
+
+        -- Get all RPC notifications captured by the mock server
+        local rpc_notifications = helpers.exec_lua(function()
+            return require("test.utils.mock_server").rpc_notifications
+        end)
+
+        -- Count didOpen notifications for first file
+        local didOpen_count_1 = 0
+        for _, notif in ipairs(rpc_notifications) do
+            if notif.method == "textDocument/didOpen" then
+                local uri = notif.params and notif.params.textDocument and notif.params.textDocument.uri
+                if uri == to_uri(vim.fs.joinpath(scratch, "Bar", "Program.cs")) then
+                    didOpen_count_1 = didOpen_count_1 + 1
+                end
+            end
+        end
+        assert.are_equal(1, didOpen_count_1, "First file should have exactly 1 didOpen")
+
+        -- Open second file in same solution (same client)
+        command("edit " .. vim.fs.joinpath(helpers.scratch, "Bar", "Other.cs"))
+        local bufnr2 = helpers.api.nvim_get_current_buf()
+
+        -- Wait for LSP to process
+        helpers.exec_lua(function()
+            vim.wait(100, function() end)
+        end)
+
+        -- Get updated RPC notifications
+        rpc_notifications = helpers.exec_lua(function()
+            return require("test.utils.mock_server").rpc_notifications
+        end)
+
+        -- Count didOpen notifications for second file
+        local didOpen_count_2 = 0
+        for _, notif in ipairs(rpc_notifications) do
+            if notif.method == "textDocument/didOpen" then
+                local uri = notif.params and notif.params.textDocument and notif.params.textDocument.uri
+                if uri == to_uri(vim.fs.joinpath(scratch, "Bar", "Other.cs")) then
+                    didOpen_count_2 = didOpen_count_2 + 1
+                end
+            end
+        end
+        assert.are_equal(1, didOpen_count_2, "Second file should have exactly 1 didOpen")
+
+        -- Switch back to first file (should NOT send duplicate didOpen)
+        command("buffer " .. bufnr1)
+
+        -- Wait for any potential duplicate to be processed (should be blocked)
+        helpers.exec_lua(function()
+            vim.wait(100, function() end)
+        end)
+
+        -- Get final RPC notifications
+        rpc_notifications = helpers.exec_lua(function()
+            return require("test.utils.mock_server").rpc_notifications
+        end)
+
+        -- Count didOpen notifications for first file again
+        local didOpen_count_final = 0
+        for _, notif in ipairs(rpc_notifications) do
+            if notif.method == "textDocument/didOpen" then
+                local uri = notif.params and notif.params.textDocument.uri
+                if uri == to_uri(vim.fs.joinpath(scratch, "Bar", "Program.cs")) then
+                    didOpen_count_final = didOpen_count_final + 1
+                end
+            end
+        end
+        assert.are_equal(1, didOpen_count_final, "First file should still have exactly 1 didOpen after switching back (no duplicate)")
+
+        -- Close the first file (should send didClose and allow reopening)
+        command("bdelete " .. bufnr1)
+
+        -- Wait for didClose to be processed
+        helpers.exec_lua(function()
+            vim.wait(100, function() end)
+        end)
+
+        -- Get RPC notifications after close
+        rpc_notifications = helpers.exec_lua(function()
+            return require("test.utils.mock_server").rpc_notifications
+        end)
+
+        -- Verify didClose was sent
+        local didClose_count = 0
+        for _, notif in ipairs(rpc_notifications) do
+            if notif.method == "textDocument/didClose" then
+                local uri = notif.params and notif.params.textDocument.uri
+                if uri == to_uri(vim.fs.joinpath(scratch, "Bar", "Program.cs")) then
+                    didClose_count = didClose_count + 1
+                end
+            end
+        end
+        assert.are_equal(1, didClose_count, "didClose should be sent when buffer is deleted")
+
+        -- Reopen the same file (should allow didOpen again after didClose)
+        command("edit " .. vim.fs.joinpath(helpers.scratch, "Bar", "Program.cs"))
+
+        -- Wait for LSP to process reopen
+        helpers.exec_lua(function()
+            vim.wait(100, function() end)
+        end)
+
+        -- Get final RPC notifications
+        rpc_notifications = helpers.exec_lua(function()
+            return require("test.utils.mock_server").rpc_notifications
+        end)
+
+        -- Count didOpen notifications for first file after reopen
+        local didOpen_count_after_reopen = 0
+        for _, notif in ipairs(rpc_notifications) do
+            if notif.method == "textDocument/didOpen" then
+                local uri = notif.params and notif.params.textDocument.uri
+                if uri == to_uri(vim.fs.joinpath(scratch, "Bar", "Program.cs")) then
+                    didOpen_count_after_reopen = didOpen_count_after_reopen + 1
+                end
+            end
+        end
+        assert.are_equal(2, didOpen_count_after_reopen, "File should have 2 didOpen after reopening (1 original + 1 after close)")
+    end)
 end)

--- a/test/utils/mock_server.lua
+++ b/test/utils/mock_server.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 M.notifications = {}
+M.rpc_notifications = {}
 
 function M.server()
     local closing = false
@@ -8,7 +9,14 @@ function M.server()
 
     function srv.request(method, _, handler)
         if method == "initialize" then
-            handler(nil, { capabilities = {} })
+            handler(nil, {
+                capabilities = {
+                    textDocumentSync = {
+                        openClose = true,
+                        change = 1,
+                    },
+                },
+            })
         elseif method == "shutdown" then
             handler(nil, nil)
         else
@@ -17,6 +25,8 @@ function M.server()
     end
 
     function srv.notify(method, params)
+        table.insert(M.rpc_notifications, { method = method, params = params })
+
         if method == "exit" then
             closing = true
         elseif method == "solution/open" or method == "project/open" then
@@ -37,6 +47,7 @@ end
 
 function M.reset()
     M.notifications = {}
+    M.rpc_notifications = {}
 end
 
 return M


### PR DESCRIPTION
When opening a `.cs` file via Telescope, neo-tree, or similar pickers, the Roslyn server crashes and stops entirely. Navigating with `gd` or `:e` works fine.

The issue is that these tools trigger `BufEnter` multiple times, causing Neovim to send a duplicate `textDocument/didOpen` for a file the server already has open. Roslyn doesn't handle this gracefully — it throws and the whole server process dies.

```
System.InvalidOperationException: didOpen received for file:///path/to/SomeFile.cs which is already open.
   at Microsoft.CodeAnalysis.LanguageServer.LspWorkspaceManager.StartTrackingAsync(...)
   at ...DidOpenHandler.HandleNotificationAsync(...)
```

Related to #299 / #304, which fixed the same class of bug for Razor virtual buffers. This one affects plain `.cs` files.
