### PR TITLE
fix(razor): handle nil response for signatureHelp

### DIFF
--- a/lua/roslyn/razor/handlers.lua
+++ b/lua/roslyn/razor/handlers.lua
@@ -1,6 +1,7 @@
 ---@type table<vim.lsp.protocol.Method.ClientToServer, any>
 local nil_responses = {
     ["textDocument/hover"] = true,
+    ["textDocument/signatureHelp"] = true,
 }
 
 ---@generic T


### PR DESCRIPTION
Add "textDocument/signatureHelp" to the list of LSP methods that may return nil responses. This ensures proper handling of signature help requests in Razor files and prevents potential errors when the server returns nil.