### PR TITLE
fix(lsp/roslyn): skip semantictokens/full for razor/cshtml

### DIFF
--- a/lsp/roslyn.lua
+++ b/lsp/roslyn.lua
@@ -105,7 +105,8 @@ return {
                 if method == "textDocument/semanticTokens/full" then
                     ---@class lsp.SemanticTokensParams
                     local res = params
-                    if res.textDocument.uri:match("%.razor$") or res.textDocument.uri:match("%.cshtml$") then
+                    local bufnr = vim.uri_to_bufnr(res.textDocument.uri)
+                    if vim.bo[bufnr].filetype == "razor" then
                         return
                     end
                 end

--- a/lsp/roslyn.lua
+++ b/lsp/roslyn.lua
@@ -92,9 +92,25 @@ return {
         on_dir(root_dir)
     end,
     on_init = {
+        ---@param client vim.lsp.Client
         function(client)
             -- Although roslyn supports prepareRename, cohosted razor doesnt. So we need to disable it
             client.server_capabilities.renameProvider = true
+
+            local orig_request = client.request
+
+            --- @param method vim.lsp.protocol.Method.ClientToServer.Request LSP method name.
+            --- @param params? table LSP request params.
+            client.request = function(_, method, params, ...)
+                if method == "textDocument/semanticTokens/full" then
+                    ---@class lsp.SemanticTokensParams
+                    local res = params
+                    if res.textDocument.uri:match("%.razor$") or res.textDocument.uri:match("%.cshtml$") then
+                        return
+                    end
+                end
+                return orig_request(client, method, params, ...)
+            end
 
             if not client.config.root_dir then
                 return

--- a/lsp/roslyn.lua
+++ b/lsp/roslyn.lua
@@ -95,7 +95,8 @@ return {
                 if method == "textDocument/semanticTokens/full" then
                     ---@class lsp.SemanticTokensParams
                     local res = params
-                    if res.textDocument.uri:match("%.razor$") or res.textDocument.uri:match("%.cshtml$") then
+                    local bufnr = vim.uri_to_bufnr(res.textDocument.uri)
+                    if vim.bo[bufnr].filetype == "razor" then
                         return
                     end
                 end

--- a/lsp/roslyn.lua
+++ b/lsp/roslyn.lua
@@ -82,9 +82,25 @@ return {
         on_dir(root_dir)
     end,
     on_init = {
+        ---@param client vim.lsp.Client
         function(client)
             -- Although roslyn supports prepareRename, cohosted razor doesnt. So we need to disable it
             client.server_capabilities.renameProvider = true
+
+            local orig_request = client.request
+
+            --- @param method vim.lsp.protocol.Method.ClientToServer.Request LSP method name.
+            --- @param params? table LSP request params.
+            client.request = function(_, method, params, ...)
+                if method == "textDocument/semanticTokens/full" then
+                    ---@class lsp.SemanticTokensParams
+                    local res = params
+                    if res.textDocument.uri:match("%.razor$") or res.textDocument.uri:match("%.cshtml$") then
+                        return
+                    end
+                end
+                return orig_request(client, method, params, ...)
+            end
 
             if not client.config.root_dir then
                 return


### PR DESCRIPTION
Roslyn's full semantic tokens request is now bypassed for .razor and .cshtml files, preventing issues with cohosted Razor where semantictokens/full are not supported. This avoids unnecessary or problematic LSP requests for these file types.