### PR TITLE
fix: refresh source generated files

### DIFF
--- a/lua/roslyn/lsp/handlers.lua
+++ b/lua/roslyn/lsp/handlers.lua
@@ -26,7 +26,7 @@ return {
         local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
         for _, buf in ipairs(vim.api.nvim_list_bufs()) do
             local uri = vim.api.nvim_buf_get_name(buf)
-            if vim.api.nvim_buf_get_name(buf):match("^roslyn%-source%-generated://") then
+            if vim.api.nvim.buf_is_loaded(buf) and uri:match("^roslyn%-source%-generated://") then
                 local function handler(err, result)
                     assert(not err, vim.inspect(err))
                     if vim.b[buf].resultId == result.resultId then

--- a/lua/roslyn/lsp/handlers.lua
+++ b/lua/roslyn/lsp/handlers.lua
@@ -33,7 +33,7 @@ return {
                         return
                     end
                     local content = result.text
-                    if content == nil then
+                    if content == nil or content == vim.NIL then
                         content = ""
                     end
                     local normalized = string.gsub(content, "\r\n", "\n")

--- a/lua/roslyn/lsp/handlers.lua
+++ b/lua/roslyn/lsp/handlers.lua
@@ -32,8 +32,8 @@ return {
                     if vim.b[buf].resultId == result.resultId then
                         return
                     end
-                    local content = result.text
-                    if content == nil or content == vim.NIL then
+                    local content = result.text or ""
+                    if content == vim.NIL then
                         content = ""
                     end
                     local normalized = string.gsub(content, "\r\n", "\n")

--- a/plugin/roslyn.lua
+++ b/plugin/roslyn.lua
@@ -58,7 +58,7 @@ vim.api.nvim_create_autocmd({ "BufReadCmd" }, {
         local function handler(err, result)
             assert(not err, vim.inspect(err))
             content = result.text
-            if content == nil then
+            if content == nil or content == vim.NIL then
                 content = ""
             end
             local normalized = string.gsub(content, "\r\n", "\n")

--- a/plugin/roslyn.lua
+++ b/plugin/roslyn.lua
@@ -57,8 +57,8 @@ vim.api.nvim_create_autocmd({ "BufReadCmd" }, {
         local content
         local function handler(err, result)
             assert(not err, vim.inspect(err))
-            content = result.text
-            if content == nil or content == vim.NIL then
+            content = result.text or ""
+            if content == vim.NIL then
                 content = ""
             end
             local normalized = string.gsub(content, "\r\n", "\n")


### PR DESCRIPTION
Fix for issues which I started noticing when working with source generated files:

1. currently handler for refreshing source gen files is trying to refresh all buffers, even if not visible to user (which I assume is not desirable). This sometimes caused a couple of issues with not being able to modify the content of buffer.

This change will cause to refresh only loaded buffers which alignes with that vscode does https://github.com/blipk/vscodium-csharp/blob/a4df3ffe66082aeef5d7aa79457d38cf7a670adc/src/lsptoolshost/sourceGeneratedFilesContentProvider.ts#L41

2. when using roslyn 5.7 sometimes content for this buffer is `vim.NIL` which currently is not checked 

3. When reopening neovim with saved source generated file (via `persistence.nvim` for example), roslyn will throw an error cause it will try fetch content of source generated buffer that no longer exists (id of document will be different)

Guess might be helpfull to add such snippet to wiki so users are aware of it

```lua
 --Disable saving source generated files which are temporary

 vim.api.nvim_create_autocmd("User", {
   pattern = "PersistenceSavePre",
   callback = function()
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
       local name = vim.api.nvim_buf_get_name(buf)
       if name:match("roslyn%-source%-generated://") then
         vim.api.nvim_buf_delete(buf, { force = true })
       end
     end
   end,
 })
```
