### PR TITLE
ci(github): add lint and typecheck workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+---
+name: Lint
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Luacheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install luarocks -y
+          sudo luarocks install luacheck
+
+      - name: Lint
+        run: luacheck lua/ --globals vim

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,28 @@
+---
+name: lua_ls-typecheck
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Type Check Code Base
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: stevearc/nvim-typecheck-action@v2
+        with:
+          path: lua
+          level: Warning
+          configpath: ".luarc.json"

--- a/.luarc.json
+++ b/.luarc.json
@@ -5,5 +5,11 @@
   },
   "type": {
     "checkTableShape": true
-  }
+  },
+    "diagnostics.globals": [
+        "describe",
+        "it",
+        "before_each",
+        "after_each"
+    ]
 }

--- a/test/utils/helpers.lua
+++ b/test/utils/helpers.lua
@@ -1,5 +1,4 @@
 local helpers = require("nvim-test.helpers")
-local command = helpers.api.nvim_command
 local system = helpers.fn.system
 
 local M = helpers


### PR DESCRIPTION
Introduce two GitHub Actions workflows for CI:
- `lint.yml` runs Luacheck on the `lua/` directory to enforce code style and catch common Lua issues.
- `typecheck.yml` uses `nvim-typecheck-action` to perform static type checking with lua_ls, using the `.luarc.json` config.

Also, remove an unused local variable from `test/utils/helpers.lua` for cleaner test helper code.