### PR TITLE
refactor(extensions)!: deprecate extensions config

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,12 +195,9 @@ To pass custom Roslyn extensions, override the server command and include one
 `--extension=/path/to/extension.dll` argument per extension.
 
 ```lua
-local resolved = require("roslyn.utils").get_roslyn_lsp_path()
-local exe = resolved and resolved.path or "Microsoft.CodeAnalysis.LanguageServer"
-
 vim.lsp.config("roslyn", {
     cmd = {
-        exe,
+        "roslyn-language-server",
         "--stdio",
         "--extension=/path/to/Roslynator.dll",
     },

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A couple of additional things this plugin implements
 - Support for source generated files
 - Support for `Fix all`, `Nested code actions` and `Complex edit`.
 - `Roslyn target` command to switch between multiple solutions
-- Support for custom roslyn extensions, like Roslynator (passed via config)
+- Support for custom roslyn extensions, like Roslynator (configured with `vim.lsp.config`)
 
 ## Demo
 
@@ -167,10 +167,6 @@ opts = {
 
     -- If the plugin should silence notifications about initialization
     silent = false,
-
-    -- Additional roslyn extensions (for example Roslynator).
-    -- The path is expected to be a .dll file.
-    extensions = {},
 }
 ```
 
@@ -191,6 +187,22 @@ vim.lsp.config("roslyn", {
         ["csharp|code_lens"] = {
             dotnet_enable_references_code_lens = true,
         },
+    },
+})
+```
+
+To pass custom Roslyn extensions, override the server command and include one
+`--extension=/path/to/extension.dll` argument per extension.
+
+```lua
+local resolved = require("roslyn.utils").get_roslyn_lsp_path()
+local exe = resolved and resolved.path or "Microsoft.CodeAnalysis.LanguageServer"
+
+vim.lsp.config("roslyn", {
+    cmd = {
+        exe,
+        "--stdio",
+        "--extension=/path/to/Roslynator.dll",
     },
 })
 ```

--- a/lsp/roslyn.lua
+++ b/lsp/roslyn.lua
@@ -10,6 +10,10 @@ local function get_default_cmd()
     }
 
     local roslyn_extensions = require("roslyn.config").get().extensions or {}
+    if next(roslyn_extensions) then
+        vim.deprecate("roslyn.nvim extensions", 'vim.lsp.config("roslyn", { cmd = ... })', "soon", "roslyn.nvim")
+    end
+
     for ext_name, extension in pairs(roslyn_extensions) do
         if extension.enabled then
             local resolved_config = type(extension.config) == "function" and extension.config() or extension.config
@@ -30,7 +34,9 @@ local function get_default_cmd()
             if resolved_config.args then
                 local resolved_args = type(resolved_config.args) == "function" and resolved_config.args()
                     or resolved_config.args
-                vim.list_extend(cmd, resolved_args)
+                if resolved_args then
+                    vim.list_extend(cmd, resolved_args)
+                end
             end
         end
     end

--- a/test/lsp_cmd_spec.lua
+++ b/test/lsp_cmd_spec.lua
@@ -1,23 +1,5 @@
 local helpers = require("test.utils.helpers")
 
-local function cmd_contains(cmd, value)
-    for _, entry in ipairs(cmd) do
-        if entry == value then
-            return true
-        end
-    end
-    return false
-end
-
-local function cmd_has_prefix(cmd, prefix)
-    for _, entry in ipairs(cmd) do
-        if type(entry) == "string" and vim.startswith(entry, prefix) then
-            return true
-        end
-    end
-    return false
-end
-
 helpers.env()
 
 describe("lsp cmd", function()
@@ -33,8 +15,8 @@ describe("lsp cmd", function()
         helpers.exec_lua("package.path = ...", package.path)
     end)
 
-    it("adds extension path and args when provided", function()
-        local cmd = helpers.exec_lua(function()
+    it("shows deprecation notice when extensions are configured", function()
+        local deprecate = helpers.exec_lua(function()
             require("roslyn.config").setup({
                 extensions = {
                     testext = {
@@ -47,82 +29,27 @@ describe("lsp cmd", function()
                 },
             })
 
-            local captured_cmd
+            local captured_deprecate
+            vim.deprecate = function(...)
+                captured_deprecate = { ... }
+            end
+
             vim.lsp.rpc = vim.lsp.rpc or {}
-            vim.lsp.rpc.start = function(c)
-                captured_cmd = c
+            vim.lsp.rpc.start = function()
                 return {}
             end
 
             local cwd = vim.uv.cwd()
             local lsp_config = dofile(vim.fs.joinpath(cwd, "lsp", "roslyn.lua"))
             lsp_config.cmd({}, { cmd_cwd = nil, cmd_env = nil, detached = nil })
-            return captured_cmd
+            return captured_deprecate
         end)
 
-        assert.is_true(cmd_contains(cmd, "--extension=/tmp/roslyn-test-extension.dll"))
-        assert.is_true(cmd_contains(cmd, "--foo=bar"))
-        assert.is_true(cmd_contains(cmd, "--baz"))
-    end)
-
-    it("skips extension when no path is provided", function()
-        local cmd = helpers.exec_lua(function()
-            require("roslyn.config").setup({
-                extensions = {
-                    testext = {
-                        enabled = true,
-                        config = { path = nil },
-                    },
-                },
-            })
-
-            local captured_cmd
-            vim.lsp.rpc = vim.lsp.rpc or {}
-            vim.lsp.rpc.start = function(c)
-                captured_cmd = c
-                return {}
-            end
-
-            local cwd = vim.uv.cwd()
-            local lsp_config = dofile(vim.fs.joinpath(cwd, "lsp", "roslyn.lua"))
-            lsp_config.cmd({}, { cmd_cwd = nil, cmd_env = nil, detached = nil })
-            return captured_cmd
-        end)
-
-        assert.is_false(cmd_has_prefix(cmd, "--extension="))
-    end)
-
-    it("supports extension config as function", function()
-        local cmd = helpers.exec_lua(function()
-            require("roslyn.config").setup({
-                extensions = {
-                    testext = {
-                        enabled = true,
-                        config = function()
-                            return {
-                                path = "/tmp/roslyn-test-extension-fn.dll",
-                                args = { "--alpha", "--beta=1" },
-                            }
-                        end,
-                    },
-                },
-            })
-
-            local captured_cmd
-            vim.lsp.rpc = vim.lsp.rpc or {}
-            vim.lsp.rpc.start = function(c)
-                captured_cmd = c
-                return {}
-            end
-
-            local cwd = vim.uv.cwd()
-            local lsp_config = dofile(vim.fs.joinpath(cwd, "lsp", "roslyn.lua"))
-            lsp_config.cmd({}, { cmd_cwd = nil, cmd_env = nil, detached = nil })
-            return captured_cmd
-        end)
-
-        assert.is_true(cmd_contains(cmd, "--extension=/tmp/roslyn-test-extension-fn.dll"))
-        assert.is_true(cmd_contains(cmd, "--alpha"))
-        assert.is_true(cmd_contains(cmd, "--beta=1"))
+        assert.are.same({
+            "roslyn.nvim extensions",
+            'vim.lsp.config("roslyn", { cmd = ... })',
+            "soon",
+            "roslyn.nvim",
+        }, deprecate)
     end)
 end)


### PR DESCRIPTION
Deprecates the `extensions` option in roslyn.nvim's config in favor of overriding the `cmd` property with `vim.lsp.config`. Updates the README with new instructions for passing custom Roslyn extensions and adds a deprecation warning when the old `extensions` config is used. Updates tests to check for the deprecation notice instead of extension argument handling.

BREAKING CHANGE: The `extensions` config option is gone