### PR TITLE
docs: remove deprecated subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,9 +336,6 @@ This setting controls how the language server should format code.
 
 ## 📚 Commands
 
-- `:Roslyn restart` restarts the server
-- `:Roslyn start` starts the server
-- `:Roslyn stop` stops the server
 - `:Roslyn target` chooses a solution if there are multiple to chose from
 
 ## 🚀 Other usage


### PR DESCRIPTION
These were left in by a mistake when we deprecated the subcommands in favor of the builtin `:lsp` command.

They still exist for now, but they are deprecated, so do not document them.