### PR TITLE
fix: Refresh lsp diagnostics only on roslyn attached buffers when workspace/projectInitializationComplete fires

### DIFF
--- a/lua/roslyn/lsp/handlers.lua
+++ b/lua/roslyn/lsp/handlers.lua
@@ -20,7 +20,7 @@ return {
             data = { client_id = ctx.client_id },
         })
 
-        -- lsp provides stale diagnostics pbefore it is fully initialized
+        -- lsp provides stale diagnostics before it is fully initialized
         local lsp_client = assert(vim.lsp.get_client_by_id(ctx.client_id))
         for bufnr in pairs(lsp_client.attached_buffers) do
             vim.lsp.diagnostic._refresh(bufnr, ctx.client_id)

--- a/lua/roslyn/lsp/handlers.lua
+++ b/lua/roslyn/lsp/handlers.lua
@@ -20,7 +20,11 @@ return {
             data = { client_id = ctx.client_id },
         })
 
-        vim.lsp.diagnostic._refresh()
+        -- lsp provides stale diagnostics pbefore it is fully initialized
+        local lsp_client = assert(vim.lsp.get_client_by_id(ctx.client_id))
+        for bufnr in pairs(lsp_client.attached_buffers) do
+            vim.lsp.diagnostic._refresh(bufnr, ctx.client_id)
+        end
     end,
     ["workspace/refreshSourceGeneratedDocument"] = function(_, _, ctx)
         local client = assert(vim.lsp.get_client_by_id(ctx.client_id))

--- a/test/lsp_integration_spec.lua
+++ b/test/lsp_integration_spec.lua
@@ -650,4 +650,46 @@ describe("LSP integration with mock server", function()
         assert.is_true(vim.tbl_contains(solutions, to_uri(vim.fs.joinpath(scratch, "src", "Bar", "Bar.sln"))))
         assert.is_true(vim.tbl_contains(solutions, to_uri(vim.fs.joinpath(scratch, "src", "Root.sln"))))
     end)
+
+    it("refreshes possibly stale diagnostics for attached buffers after initialization", function()
+        create_sln_file("Foo.sln", { { name = "Bar", path = "Bar/Bar.csproj" } })
+        create_file("Bar/Bar.csproj")
+        create_file("Bar/Program.cs")
+
+        command("edit " .. vim.fs.joinpath(helpers.scratch, "Bar", "Program.cs"))
+
+        local cs_uri = helpers.exec_lua(function()
+            return vim.uri_from_bufnr(vim.api.nvim_get_current_buf())
+        end)
+
+        local client_id = helpers.exec_lua(function()
+            return vim.lsp.get_clients({ name = "roslyn" })[1].id
+        end)
+
+        -- Move away the focus to ensure 'valid' buffers only are part of the refresh
+        -- Resembles the buggy behaviour of https://github.com/seblyng/roslyn.nvim/issues/371
+        command("enew")
+
+        local uris = helpers.exec_lua(function(id, uri)
+            local mock_server = require("test.utils.mock_server")
+            mock_server.diagnostic_requests = {}
+
+            require("roslyn.lsp.handlers")["workspace/projectInitializationComplete"](nil, nil, { client_id = id })
+
+            vim.wait(1000, function()
+                return vim.iter(mock_server.diagnostic_requests):any(function(req)
+                    return req.uri == uri
+                end)
+            end)
+
+            return vim.tbl_map(function(req)
+                return req.uri
+            end, mock_server.diagnostic_requests)
+        end, client_id, cs_uri)
+
+        assert.is_true(vim.tbl_contains(uris, cs_uri))
+        for _, uri in ipairs(uris) do
+            assert.is_true(uri:match("Program%.cs$") ~= nil)
+        end
+    end)
 end)

--- a/test/utils/mock_server.lua
+++ b/test/utils/mock_server.lua
@@ -1,16 +1,27 @@
 local M = {}
 
 M.notifications = {}
+M.diagnostic_requests = {}
 
 function M.server()
     local closing = false
     local srv = {}
 
-    function srv.request(method, _, handler)
+    function srv.request(method, params, handler)
         if method == "initialize" then
-            handler(nil, { capabilities = {} })
+            handler(nil, {
+                capabilities = {
+                    diagnosticProvider = {
+                        interFileDependencies = true,
+                        workspaceDiagnostics = false,
+                    },
+                },
+            })
         elseif method == "shutdown" then
             handler(nil, nil)
+        elseif method == "textDocument/diagnostic" then
+            table.insert(M.diagnostic_requests, { uri = params.textDocument.uri })
+            handler(nil, { kind = "full", items = {} })
         else
             assert(false, "Unhandled method: " .. method)
         end
@@ -37,6 +48,7 @@ end
 
 function M.reset()
     M.notifications = {}
+    M.diagnostic_requests = {}
 end
 
 return M


### PR DESCRIPTION
Closes #371 