### PR TITLE
chore!: remove initialize progress code

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,6 @@ opts = {
     -- This will always attach to the target in `vim.g.roslyn_nvim_selected_solution`.
     -- NOTE: You can use `:Roslyn target` to change the target
     lock_target = false,
-
-    -- If the plugin should silence notifications about initialization
-    silent = false,
 }
 ```
 

--- a/lua/roslyn/config.lua
+++ b/lua/roslyn/config.lua
@@ -14,7 +14,6 @@ local M = {}
 ---@field ignore_target? fun(target: string): boolean
 ---@field broad_search boolean
 ---@field lock_target boolean
----@field silent boolean
 ---@field debug boolean
 ---@field extensions? table<string, RoslynExtension>
 
@@ -24,7 +23,6 @@ local M = {}
 ---@field ignore_target? fun(target: string): boolean
 ---@field broad_search? boolean
 ---@field lock_target? boolean
----@field silent? boolean
 ---@field debug? boolean
 ---@field extensions? table<string, RoslynExtension>
 
@@ -35,7 +33,6 @@ local roslyn_config = {
     ignore_target = nil,
     broad_search = false,
     lock_target = false,
-    silent = false,
     debug = false,
     extensions = {},
 }

--- a/lua/roslyn/lsp/handlers.lua
+++ b/lua/roslyn/lsp/handlers.lua
@@ -10,16 +10,6 @@ return {
         return vim.lsp.handlers["client/registerCapability"](err, res, ctx)
     end,
     ["workspace/projectInitializationComplete"] = function(_, _, ctx)
-        if not require("roslyn.config").get().silent then
-            vim.notify("Roslyn project initialization complete", vim.log.levels.INFO, { title = "roslyn.nvim" })
-        end
-
-        vim.api.nvim_exec_autocmds("User", {
-            pattern = "RoslynInitialized",
-            modeline = false,
-            data = { client_id = ctx.client_id },
-        })
-
         -- lsp provides stale diagnostics before it is fully initialized
         local lsp_client = assert(vim.lsp.get_client_by_id(ctx.client_id))
         for bufnr in pairs(lsp_client.attached_buffers) do

--- a/lua/roslyn/lsp/on_init.lua
+++ b/lua/roslyn/lsp/on_init.lua
@@ -3,41 +3,16 @@ local M = {}
 function M.sln(client, solution)
     require("roslyn.store").set(client.id, solution)
 
-    if not require("roslyn.config").get().silent then
-        vim.notify("Initializing Roslyn for: " .. solution, vim.log.levels.INFO, { title = "roslyn.nvim" })
-    end
-
     client:notify("solution/open", {
         solution = vim.uri_from_fname(solution),
-    })
-
-    vim.api.nvim_exec_autocmds("User", {
-        pattern = "RoslynOnInit",
-        data = {
-            type = "solution",
-            target = solution,
-            client_id = client.id,
-        },
     })
 end
 
 function M.project(client, projects)
-    if not require("roslyn.config").get().silent then
-        vim.notify("Initializing Roslyn for: project", vim.log.levels.INFO, { title = "roslyn.nvim" })
-    end
     client:notify("project/open", {
         projects = vim.tbl_map(function(file)
             return vim.uri_from_fname(file)
         end, projects),
-    })
-
-    vim.api.nvim_exec_autocmds("User", {
-        pattern = "RoslynOnInit",
-        data = {
-            type = "project",
-            target = projects,
-            client_id = client.id,
-        },
     })
 end
 


### PR DESCRIPTION
Initialization progress is now a part of the server itself, so the autocmds used to implement fidget notifications, and the prints behind the silent options can be removed